### PR TITLE
Create a basic idea for what the github action would look like...

### DIFF
--- a/.github/workflows/changeset-track-deps.yml
+++ b/.github/workflows/changeset-track-deps.yml
@@ -1,0 +1,39 @@
+name: Changeset dependency upgrades
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+env:
+  node_version: 14
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+      - run: yarn --frozen-lockfile --ignore-engines
+        env:
+          CI: true
+      - name: Create the changeset file
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const script = require('./scripts/add-dep-changeset.js')
+            console.log(script({github, context}))
+      # magically run a step that creates a `.changeset/*.md` file w/ a description of the dependency upgrade
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[ci] Add changeset for ${{steps.dependabot-metadata.outputs.dependency-names}} version bump'
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/scripts/add-dep-changeset.js
+++ b/.github/workflows/scripts/add-dep-changeset.js
@@ -1,0 +1,19 @@
+module.exports = ({ github, context }) => {
+  const fs = require('fs');
+
+  const content = `---
+'prettier-plugin-astro': patch
+---
+
+Bump ${context.steps['dependabot-metadata'].outputs['dependency-names']}
+
+${JSON.stringify(context.steps['dependabot-metadata'].outputs, null, 2)}
+`;
+
+  fs.writeFile(`./.changeset/${context.steps['dependabot-metadata'].outputs['dependency-names']}.md`, content, (err) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+};


### PR DESCRIPTION
## Changes

- Adds a github action that runs on dependabot PR - this is meant to automatically add a `patch` changeset to dependency upgrades, so that they are reflected in the changelog w/ minimal effort.

Atm, I don't think it works...

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
