### PR TITLE
set `astroAllowShorthand` to default off

### DIFF
--- a/.changeset/selfish-cherries-grab.md
+++ b/.changeset/selfish-cherries-grab.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+set shorthand attributes to default off

--- a/.changeset/selfish-cherries-grab.md
+++ b/.changeset/selfish-cherries-grab.md
@@ -2,4 +2,4 @@
 'prettier-plugin-astro': patch
 ---
 
-set shorthand attributes to default off
+Set astroAllowShorthand default option to false

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,7 +32,7 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
     since: '0.0.10',
     category: 'Astro',
     type: 'boolean',
-    default: true,
+    default: false,
     description:
       'Enable/disable attribute shorthand if attribute name and expression are the same',
   },

--- a/test/fixtures/converts-to-shorthand/input.astro
+++ b/test/fixtures/converts-to-shorthand/input.astro
@@ -1,5 +1,0 @@
----
-const style = "color:red;";
-let id = "#aloha";
----
-<div {id} style={style}>Hello World</div>

--- a/test/fixtures/converts-to-shorthand/output.astro
+++ b/test/fixtures/converts-to-shorthand/output.astro
@@ -1,6 +1,0 @@
----
-const style = "color:red;";
-let id = "#aloha";
----
-
-<div {id} {style}>Hello World</div>

--- a/test/fixtures/style-tag-attributes/output.astro
+++ b/test/fixtures/style-tag-attributes/output.astro
@@ -3,7 +3,7 @@
   lang="scss"
   media={"all and (max-width: 500px)"}
   type={type2}
-  {title}
+  title={title}
   id={10}
   anObject={{ prop: "value" }}
 >

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -26,10 +26,10 @@ test(
   'expr-and-html-comment'
 );
 
-test(
-  'converts valid shorthand variables into shorthand',
-  'converts-to-shorthand'
-);
+// test(
+//   'converts valid shorthand variables into shorthand',
+//   'converts-to-shorthand'
+// );
 
 // test.failing('an Astro file with an invalidly unclosed tag is still formatted', Prettier, 'unclosed-tag');
 

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -26,11 +26,6 @@ test(
   'expr-and-html-comment'
 );
 
-// test(
-//   'converts valid shorthand variables into shorthand',
-//   'converts-to-shorthand'
-// );
-
 // test.failing('an Astro file with an invalidly unclosed tag is still formatted', Prettier, 'unclosed-tag');
 
 test(


### PR DESCRIPTION
Shorthand removes attribute keys and breaks Typescript which is used by Astro. It's also uncommon and should be disabled by default, and only opt-in for those that specifically want it.

## Changes

- Sets `astroAllowShorthand` to default `false`

## Testing

No new tests.

## Docs

No documentation to update.