### PR TITLE
Disable vitest multi-threading

### DIFF
--- a/.changeset/stale-terms-help.md
+++ b/.changeset/stale-terms-help.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Disable vitest multi-threading

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    threads: false,
+  },
+});


### PR DESCRIPTION
## Changes

- Disables vitest multi-threading. It was causing a lot of crashes.

## Testing

## Docs