### PR TITLE
Fix: duplicate text

### DIFF
--- a/.changeset/moody-queens-fail.md
+++ b/.changeset/moody-queens-fail.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix: prevent duplicate text

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -74,6 +74,7 @@ import {
   // trimChildren,
   trimTextNodeLeft,
   trimTextNodeRight,
+  removeDuplicates,
 } from './utils';
 
 // function printTopLevelParts(node: RootNode, path: AstPath, opts: ParserOptions, print: printFn): Doc {
@@ -163,6 +164,7 @@ function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
   // 3. handle printing
   switch (node.type) {
     case 'root': {
+      removeDuplicates(node);
       return [stripTrailingHardline(path.map(print, 'children')), hardline];
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -745,3 +745,27 @@ export function isInsideQuotedAttribute(path: AstPath): boolean {
     (node) => node.type === 'attribute' && !isLoneMustacheTag(node)
   );
 }
+
+/**
+ * Currently the compiler has a bug wich duplicates text nodes when no
+ *  TagLikeNode elements are present
+ */
+export function removeDuplicates(root: RootNode) {
+  root.children = root.children.filter((node, i, rootChildren) => {
+    if (node.type !== 'text') return true;
+    // https://stackoverflow.com/questions/2218999/how-to-remove-all-duplicates-from-an-array-of-objects
+    return (
+      i ===
+      rootChildren.findIndex((t) => {
+        if (t.position && node.position) {
+          return (
+            node.type === 'text' &&
+            t.position.start.offset === node.position.start.offset &&
+            t.position.start.line === node.position.start.line &&
+            t.position.start.column === node.position.start.column
+          );
+        }
+      })
+    );
+  });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -747,8 +747,8 @@ export function isInsideQuotedAttribute(path: AstPath): boolean {
 }
 
 /**
- * Currently the compiler has a bug wich duplicates text nodes when no
- *  TagLikeNode elements are present
+ * Currently, the compiler has a bug that duplicates text nodes when no
+ *  TagLikeNode elements are present.
  */
 export function removeDuplicates(root: RootNode) {
   root.children = root.children.filter((node, i, rootChildren) => {

--- a/test/fixtures/basic/simple-text/input.astro
+++ b/test/fixtures/basic/simple-text/input.astro
@@ -1,0 +1,4 @@
+lorem
+
+Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus aut culpa vero amet ab libero cum consectetur. Voluptatibus a ullam, accusamus necessitatibus vero perferendis totam nam adipisci, officia iusto minima consequatur eius vel! Accusantium laborum obcaecati laudantium quis quas itaque
+optio molestias aperiam, molestiae sint dolor architecto, nemo dicta perferendis.

--- a/test/fixtures/basic/simple-text/output.astro
+++ b/test/fixtures/basic/simple-text/output.astro
@@ -1,0 +1,6 @@
+lorem Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus aut
+culpa vero amet ab libero cum consectetur. Voluptatibus a ullam, accusamus
+necessitatibus vero perferendis totam nam adipisci, officia iusto minima
+consequatur eius vel! Accusantium laborum obcaecati laudantium quis quas itaque
+optio molestias aperiam, molestiae sint dolor architecto, nemo dicta
+perferendis.

--- a/test/tests/basic.test.ts
+++ b/test/tests/basic.test.ts
@@ -4,10 +4,12 @@ const files = import.meta.glob('/test/fixtures/basic/*/*', {
   assert: { type: 'raw' },
 });
 
-test('can format a basic astro file', files, 'basic/basic-html');
+test('Can format a basic astro file', files, 'basic/basic-html');
 
 test(
-  'can format an Astro file with a single style element',
+  'Can format an Astro file with a single style element',
   files,
   'basic/single-style-element'
 );
+
+test('Can format a basic astro only text', files, 'basic/simple-text');

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -4,27 +4,27 @@ const files = import.meta.glob('/test/fixtures/other/*/*', {
   assert: { type: 'raw' },
 });
 
-test('can format an Astro file with frontmatter', files, 'other/frontmatter');
+test('Can format an Astro file with frontmatter', files, 'other/frontmatter');
 
 test(
-  'can format an Astro file with embedded JSX expressions',
+  'Can format an Astro file with embedded JSX expressions',
   files,
   'other/embedded-expr'
 );
 
 test(
-  'can format an Astro file with a `<!DOCTYPE html>` + embedded JSX expressions',
+  'Can format an Astro file with a `<!DOCTYPE html>` + embedded JSX expressions',
   files,
   'other/doctype-with-embedded-expr'
 );
 
 // // note(drew): this should be fixed in new Parser. And as this is an HTML4 / deprecated / extreme edge case, probably fine to ignore?
-// test.failing('can format an Astro file with `<!DOCTYPE>` with extraneous attributes', Prettier, 'doctype-with-extra-attributes');
+// test.failing('Can format an Astro file with `<!DOCTYPE>` with extraneous attributes', Prettier, 'doctype-with-extra-attributes');
 
-test('can format an Astro file with fragments', files, 'other/fragment');
+test('Can format an Astro file with fragments', files, 'other/fragment');
 
 test(
-  'can format an Astro file with a JSX expression in an attribute',
+  'Can format an Astro file with a JSX expression in an attribute',
   files,
   'other/attribute-with-embedded-expr'
 );
@@ -34,7 +34,7 @@ test('does not alter html comments', files, 'other/html-comment', {
 });
 
 test(
-  'can format an Astro file with a JSX expression and an HTML Comment',
+  'Can format an Astro file with a JSX expression and an HTML Comment',
   files,
   'other/expr-and-html-comment'
 );
@@ -42,7 +42,7 @@ test(
 // test.failing('an Astro file with an invalidly unclosed tag is still formatted', Prettier, 'unclosed-tag');
 
 test(
-  'can format an Astro file with components that are the uppercase version of html elements',
+  'Can format an Astro file with components that are the uppercase version of html elements',
   files,
   'other/preserve-tag-case'
 );
@@ -50,7 +50,7 @@ test(
 test('Autocloses open tags.', files, 'other/autocloses-open-tags');
 
 test(
-  'can format an Astro file with a script tag inside it',
+  'Can format an Astro file with a script tag inside it',
   files,
   'other/with-script'
 );
@@ -74,6 +74,6 @@ test('Format spread operator', files, 'other/spread-operator');
 
 test('Can format nested comment', files, 'other/nested-comment');
 
-test('format binary expressions', files, 'other/binary-expression');
+test('Format binary expressions', files, 'other/binary-expression');
 
-test('format directives', files, 'other/directive');
+test('Format directives', files, 'other/directive');


### PR DESCRIPTION
## Changes

- Removes duplicated text nodes from the ast.  Currently, the compiler has a bug that duplicates text nodes when no tag-like node elements are present.

## Testing

- Test added

## Docs