### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When submitting issues about formatting in VS Code, first make sure you're actua
 
 Due to an upstream issue, Prettier inside VS Code isn't able to automatically infer the right parser to use for Astro files when using pnpm
 
-As such, add the following settings to your `.prettierc.js` config file:
+As such, add the following settings to your `.prettierrc.js` config file:
 
 ```js
 module.exports = {


### PR DESCRIPTION
## Changes

- Fix typo in README

## Testing

N/A

## Docs

- Change `.prettierc.js` -> `.prettierrc.js`
