### PR TITLE
Fix shorthand props not working inside expressions and update error handling

### DIFF
--- a/.changeset/purple-mangos-drum.md
+++ b/.changeset/purple-mangos-drum.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Update error handling to give better error messages when we fail to parse an expression, fixed shorthands props not working inside expressions

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-this-alias": "off",
-    "no-console": "warn",
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": ["error"],
     "prettier/prettier": "warn"

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -1,7 +1,7 @@
 import { BuiltInParsers, Doc, ParserOptions } from 'prettier';
 import _doc from 'prettier/doc';
 import { SassFormatter, SassFormatterConfig } from 'sass-formatter';
-import { anyNode } from './nodes';
+import { anyNode, ExpressionNode } from './nodes';
 import {
 	AstPath,
 	isNodeWithChildren,
@@ -34,7 +34,7 @@ export function embed(
 		const originalContent = printRaw(node);
 		(opts as any).originalContent = originalContent;
 
-		const jsxNode = makeExpressionJSXCompatible(node);
+		const jsxNode = makeNodeJSXCompatible<ExpressionNode>(node);
 		const textContent = printRaw(jsxNode);
 
 		let content: Doc;
@@ -156,7 +156,7 @@ function expressionParser(text: string, parsers: BuiltInParsers, opts: ParserOpt
  * - Astro allows a shorthand syntax for props. ex: `<Component {props} />`
  * - Astro allows multiple root elements. ex: `<div></div><div></div>`
  */
-function makeExpressionJSXCompatible(node: anyNode): anyNode {
+function makeNodeJSXCompatible<T>(node: any): T {
 	const newNode = { ...node };
 
 	if (isNodeWithChildren(newNode)) {
@@ -172,7 +172,7 @@ function makeExpressionJSXCompatible(node: anyNode): anyNode {
 				});
 
 				if (isNodeWithChildren(child)) {
-					(child as anyNode) = makeExpressionJSXCompatible(child);
+					child = makeNodeJSXCompatible(child);
 				}
 			}
 		});

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -170,6 +170,10 @@ function makeExpressionJSXCompatible(node: anyNode): anyNode {
 						attr.name = '__PRETTIER_SNIP__' + attr.name;
 					}
 				});
+
+				if (isNodeWithChildren(child)) {
+					(child as anyNode) = makeExpressionJSXCompatible(child);
+				}
 			}
 		});
 	}

--- a/test/fixtures/other/shorthand-in-expression/input.astro
+++ b/test/fixtures/other/shorthand-in-expression/input.astro
@@ -1,0 +1,5 @@
+{enabled && <Header
+
+
+
+{content} />}

--- a/test/fixtures/other/shorthand-in-expression/input.astro
+++ b/test/fixtures/other/shorthand-in-expression/input.astro
@@ -3,3 +3,16 @@
 
 
 {content} />}
+
+{enabled && <Header
+
+
+hello={hello}
+{content} />}
+
+{[].map((item) => {
+  return <>
+    <Header hello={hello} {content} />
+    <Header {content} />
+  </>})
+}

--- a/test/fixtures/other/shorthand-in-expression/output.astro
+++ b/test/fixtures/other/shorthand-in-expression/output.astro
@@ -1,0 +1,1 @@
+{enabled && <Header {content} />}

--- a/test/fixtures/other/shorthand-in-expression/output.astro
+++ b/test/fixtures/other/shorthand-in-expression/output.astro
@@ -1,1 +1,12 @@
 {enabled && <Header {content} />}
+
+{enabled && <Header hello={hello} {content} />}
+
+{[].map((item) => {
+  return (
+    <>
+      <Header hello={hello} {content} />
+      <Header {content} />
+    </>
+  );
+})}

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -67,3 +67,9 @@ test('Format binary expressions', files, 'other/binary-expression');
 test('Format directives', files, 'other/directive');
 
 test('Format slots', files, 'other/slots');
+
+test(
+	'Can format expressions with shorthands props in them',
+	files,
+	'other/shorthand-in-expression'
+);


### PR DESCRIPTION
## Changes

This PR does two things:
- Fixed shorthands props not working in expression. This is a more complicated issue than it might seems because inside expressions, we use a TypeScript parser and as such, Astro-isms will cause a parsing error. I solve this by first transforming the expression into a JSX compatible one and then re-adding the Astro-ism once it's formatted
- Changed how error handling works when we can't parse an expression, now the plugin will report the error, but won't actually fail. Instead the node will be left as-is. This is consistant with how other Prettier plugins work (ex: the Svelte one does this, so does the official MDX one (I believe?)). If `PRETTIER_DEBUG=1` is set, then the plugin will throw like before (just like official Prettier plugins does)

Both changes didn't need to be done in the same PR, however updating the error handling made it easier to implement the shorthand fix in a nice way

Fix https://github.com/withastro/prettier-plugin-astro/issues/168
Fix https://github.com/withastro/prettier-plugin-astro/issues/224

## Testing

Added a test

## Docs

N/A