### PR TITLE
More consistent error handling, properly throw with good error message on parsing fail

### DIFF
--- a/.changeset/stupid-peas-mate.md
+++ b/.changeset/stupid-peas-mate.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Improve error handling for frontmatter and script tags


### PR DESCRIPTION
## Changes

Further work on error handling after a night of sleep after https://github.com/withastro/prettier-plugin-astro/pull/246

This PR makes it so we throw and provide a good error message on parsing fails, why the change of mind from the previous PR where I decided not to throw?

- I figured how to throw with a good error message
- Explicit errors are better so users can help us figure it out when it's our fault the parsing failed
- Better experience in VS Code (the Prettier icon change to a warning sign when it couldn't parse)

Also, with this PR the behaviour is now consistent between the frontmatter / script tags and expressions

Before
<img width="742" alt="image" src="https://user-images.githubusercontent.com/3019731/182904214-6af35eb2-bcc1-4346-a7f7-54711ad47bbd.png">

After
<img width="430" alt="image" src="https://user-images.githubusercontent.com/3019731/182904128-1b38f70a-0f6b-4ce9-977f-5be7b95aff50.png">

(The TypeScript's parsers error are really good looking, might be inspiration for `astro check` 🤔)

## Testing

N/A, I think? Testing that the TypeScript or Babel parsers properly throw doesn't seem pertinent to me

## Docs

N/A
