### PR TITLE
Properly handle errors inside style tags

### DIFF
--- a/.changeset/quiet-dots-thank.md
+++ b/.changeset/quiet-dots-thank.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Properly handle errors inside style tags

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -200,11 +200,17 @@ function embedStyle(
 		case 'css':
 		case 'scss': {
 			let formattedStyles;
-			formattedStyles = textToDoc(content, {
-				...options,
-				parser: (text: string, parsers: BuiltInParsers, opts: ParserOptions) =>
-					wrapParserTryCatch(parsers[lang], text, opts),
-			});
+
+			// NOTE: Due to a bug in Prettier, we can't use our wrapParserTryCatch function here or parsing will silently fail
+			try {
+				formattedStyles = textToDoc(content, {
+					...options,
+					parser: lang,
+				});
+			} catch (e) {
+				process.env.PRETTIER_DEBUG = 'true';
+				throw e;
+			}
 
 			// The css parser appends an extra indented hardline, which we want outside of the `indent()`,
 			// so we remove the last element of the array

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -30,10 +30,6 @@ export function embed(
 	if (!node) return null;
 
 	if (node.type === 'expression') {
-		// This is a bit of a hack, but I'm not sure how else to pass the original, pre-JSX transformations to the parser?
-		const originalContent = printRaw(node);
-		(opts as any).originalContent = originalContent;
-
 		const jsxNode = makeNodeJSXCompatible<ExpressionNode>(node);
 		const textContent = printRaw(jsxNode);
 
@@ -203,9 +199,11 @@ function embedStyle(
 	switch (lang) {
 		case 'css':
 		case 'scss': {
-			let formattedStyles = textToDoc(content, {
+			let formattedStyles;
+			formattedStyles = textToDoc(content, {
 				...options,
-				parser: lang,
+				parser: (text: string, parsers: BuiltInParsers, opts: ParserOptions) =>
+					wrapParserTryCatch(parsers[lang], text, opts),
 			});
 
 			// The css parser appends an extra indented hardline, which we want outside of the `indent()`,


### PR DESCRIPTION
## Changes

Add a try catch around the CSS parsing to handle errors properly like we do for the frontmatter and script tags

<img width="479" alt="image" src="https://user-images.githubusercontent.com/3019731/183308825-0da0f1f9-672e-4368-bf13-d1d831b6fea9.png">

Fix https://github.com/withastro/prettier-plugin-astro/issues/215

## Testing

Tested manually

## Docs

N/A
