### PR TITLE
Support resolving a non-relative path for workers

### DIFF
--- a/.changeset/silent-laws-attack.md
+++ b/.changeset/silent-laws-attack.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Fix loading workers not working when parser is used from an external module

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,14 @@ import { options } from './options';
 import { print } from './printer';
 import { embed } from './printer/embed';
 
-const require = createRequire(import.meta.url);
-// the worker path must be absolute
-const parse = createSyncFn(require.resolve('../workers/parse-worker.js'));
+const req = createRequire(import.meta.url);
+let workerPath;
+try {
+	workerPath = req.resolve('prettier-plugin-astro/workers/parse-worker.js');
+} catch (e) {
+	workerPath = req.resolve('../workers/parse-worker.js');
+}
+const parse = createSyncFn(req.resolve(workerPath));
 
 // https://prettier.io/docs/en/plugins.html#languages
 export const languages: Partial<SupportLanguage>[] = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import { embed } from './printer/embed';
 const req = createRequire(import.meta.url);
 let workerPath;
 try {
-	workerPath = req.resolve('prettier-plugin-astro/workers/parse-worker.js');
-} catch (e) {
 	workerPath = req.resolve('../workers/parse-worker.js');
+} catch (e) {
+	workerPath = req.resolve('prettier-plugin-astro/workers/parse-worker.js');
 }
 const parse = createSyncFn(req.resolve(workerPath));
 

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -8,8 +8,14 @@ export type printFn = (path: AstPath) => Doc;
 export type ParserOptions = ParserOpts<anyNode>;
 export type AstPath = AstP<anyNode>;
 
-const require = createRequire(import.meta.url);
-const serialize = createSyncFn(require.resolve('../workers/serialize-worker.js'));
+const req = createRequire(import.meta.url);
+let workerPath;
+try {
+	workerPath = req.resolve('../workers/serialize-worker.js');
+} catch (e) {
+	workerPath = req.resolve('prettier-plugin-astro/workers/serialize-worker.js');
+}
+const serialize = createSyncFn(req.resolve(workerPath));
 
 export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNode): boolean {
 	return node && node.type === 'element' && !isBlockElement(node, opts) && !isPreTagContent(path);


### PR DESCRIPTION
## Changes

Add a fallback to our workers resolutions to support loading them non-relative to `import.meta.url`. This is needed for when another plugin uses our parser (ex: this is needed for `prettier-plugin-tailwindcss` support 😄)

Looking forward to not needing those workers at all when Prettier 3 lands 👼

## Testing

Tested manually, tests still pass

## Docs

N/A
