### PR TITLE
Trim the class attribute

### DIFF
--- a/.changeset/good-cougars-explain.md
+++ b/.changeset/good-cougars-explain.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Properly trim the class attribute on HTML elements

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -15,6 +15,7 @@ import {
 	isTextNodeStartingWithLinebreak,
 	isTextNodeStartingWithWhitespace,
 	ParserOptions,
+	printClassNames,
 	printFn,
 	printRaw,
 	shouldHugEnd,
@@ -248,10 +249,16 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 					return [line, name];
 				case 'expression':
 					// Handled in the `embed` function
-					// See embed.ts at the root of the src folder
+					// See embed.ts
 					return '';
 				case 'quoted':
-					return [line, name, '=', quote, node.value, quote];
+					let value = node.value;
+
+					if (node.name === 'class') {
+						value = printClassNames(value);
+					}
+
+					return [line, name, '=', quote, value, quote];
 				case 'shorthand':
 					return [line, '{', name, '}'];
 				case 'spread':

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -170,6 +170,10 @@ export function trimTextNodeRight(node: TextNode): void {
 	node.value = node.value && node.value.trimEnd();
 }
 
+export function printClassNames(value: string) {
+	return value.trim().split(/\s+/).join(' ');
+}
+
 /** dedent string & return tabSize (the last part is what we need) */
 export function manualDedent(input: string): {
 	tabSize: number;

--- a/test/fixtures/basic/html-class-attribute/input.astro
+++ b/test/fixtures/basic/html-class-attribute/input.astro
@@ -1,0 +1,1 @@
+<div class="  sm:p-0   p-0 "></div>

--- a/test/fixtures/basic/html-class-attribute/output.astro
+++ b/test/fixtures/basic/html-class-attribute/output.astro
@@ -1,0 +1,1 @@
+<div class="sm:p-0 p-0"></div>

--- a/test/tests/basic.test.ts
+++ b/test/tests/basic.test.ts
@@ -13,3 +13,5 @@ test('Can format a basic astro only text', files, 'basic/simple-text');
 test('Can format html comments', files, 'basic/html-comment');
 
 test('Can format HTML custom elements', files, 'basic/html-custom-elements');
+
+test('Can properly format the class attribute', files, 'basic/html-class-attribute');


### PR DESCRIPTION
## Changes

Prettier's HTML printer does this. So we should also do it! Also, this is needed to make us pass `prettier-plugin-tailwindcss`'s test suite 👼 

## Testing

Added a test

## Docs

N/A
