### PR TITLE
Fix TypeScript not working inside expression

### DIFF
--- a/.changeset/swift-books-melt.md
+++ b/.changeset/swift-books-melt.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix TypeScript not working inside expressions

--- a/test/fixtures/other/typescript-expression/input.astro
+++ b/test/fixtures/other/typescript-expression/input.astro
@@ -1,0 +1,11 @@
+{
+	[].map((item: string) => <div>
+	{item}
+	</div>)
+}
+
+<div class={[].map((item: string) =>
+
+
+
+item).join()}></div>

--- a/test/fixtures/other/typescript-expression/output.astro
+++ b/test/fixtures/other/typescript-expression/output.astro
@@ -1,0 +1,3 @@
+{[].map((item: string) => <div>{item}</div>)}
+
+<div class={[].map((item: string) => item).join()}></div>

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -81,3 +81,9 @@ test(
 );
 
 test('Can format JSX comments properly', files, 'other/jsx-comments');
+
+test(
+	'Can format expression with TypeScript in them properly',
+	files,
+	'other/typescript-expression'
+);


### PR DESCRIPTION
## Changes

A bit unfortunate, but this essentially revert a lot of what I did in https://github.com/withastro/prettier-plugin-astro/pull/255 regarding the `__js_expression` parser. However, I found another way to achieve the same result, so not all is lost!

Fix https://github.com/withastro/prettier-plugin-astro/issues/259

## Testing

Added a test, tests still pass

## Docs

N/A
