### PR TITLE
Correctly break long self-closing tags

### DIFF
--- a/.changeset/grumpy-paws-grab.md
+++ b/.changeset/grumpy-paws-grab.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Correctly break self-closing tags

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -108,7 +108,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 			const attributes = join(attributeLine, path.map(print, 'attributes'));
 
 			if (isSelfClosingTag) {
-				return group(['<', node.name, indent(group(attributes)), line, `/>`]);
+				return group(['<', node.name, indent(attributes), line, `/>`]);
 			}
 
 			if (node.children) {

--- a/test/fixtures/basic/self-closing/input.astro
+++ b/test/fixtures/basic/self-closing/input.astro
@@ -1,0 +1,7 @@
+<Image src="https://picsum.photos/200/300" alt="A random image" brightness={0.5} />
+
+<Image
+  src="https://picsum.photos/200/300"
+  alt="A random image"
+  brightness={0.5}
+/>

--- a/test/fixtures/basic/self-closing/output.astro
+++ b/test/fixtures/basic/self-closing/output.astro
@@ -1,0 +1,11 @@
+<Image
+  src="https://picsum.photos/200/300"
+  alt="A random image"
+  brightness={0.5}
+/>
+
+<Image
+  src="https://picsum.photos/200/300"
+  alt="A random image"
+  brightness={0.5}
+/>

--- a/test/tests/basic.test.ts
+++ b/test/tests/basic.test.ts
@@ -15,3 +15,5 @@ test('Can format html comments', files, 'basic/html-comment');
 test('Can format HTML custom elements', files, 'basic/html-custom-elements');
 
 test('Can properly format the class attribute', files, 'basic/html-class-attribute');
+
+test('Can format long self-closing tags with multiple attributes', files, 'basic/self-closing');


### PR DESCRIPTION
# Changes

Correctly break self-closing tags with attributes onto multiple lines when necessary.

Fixes #142

## Testing

- [x] Added `basic/self-closing` test

## Docs

- [x] Added changeset
