### PR TITLE
Don't add whitespace to inline elements

### DIFF
--- a/.changeset/beige-geckos-speak.md
+++ b/.changeset/beige-geckos-speak.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+End tag hugs text nodes not ending in whitespace

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Set if attributes with the same name as their expression should be formatted to 
 
 Pull requests of any size and any skill level are welcome, no contribution is too small. Changes to the Astro Prettier Plugin are subject to [Astro Governance](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) and should adhere to the [Astro Style Guide](https://github.com/withastro/astro/blob/main/STYLE_GUIDE.md)
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to setup your development environnement
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to set up your development environment.
 
 ## Sponsors
 

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -86,11 +86,15 @@ export function endsWithLinebreak(text: string, nrLines = 1): boolean {
 }
 
 export function isTextNodeStartingWithWhitespace(node: Node): node is TextNode {
-	return node.type === 'text' && /^\s/.test(getUnencodedText(node));
+	return isTextNode(node) && /^\s/.test(getUnencodedText(node));
+}
+
+function endsWithWhitespace(text: string) {
+	return /\s$/.test(text);
 }
 
 export function isTextNodeEndingWithWhitespace(node: Node): node is TextNode {
-	return node.type === 'text' && /\s$/.test(getUnencodedText(node));
+	return isTextNode(node) && endsWithWhitespace(getUnencodedText(node));
 }
 
 /**
@@ -133,11 +137,9 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 		return true;
 	}
 
-	return false;
-
-	// TODO: WIP
-	// const lastChild = children[children.length - 1];
-	// return !isTextNodeEndingWithWhitespace(lastChild);
+	const lastChild = children[children.length - 1];
+	if (!isTextNode(lastChild)) return false;
+	return !endsWithWhitespace(getUnencodedText(lastChild));
 }
 
 /**

--- a/test/fixtures/basic/inline-whitespace/input.astro
+++ b/test/fixtures/basic/inline-whitespace/input.astro
@@ -1,0 +1,1 @@
+<a href="/">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eum culpa quaerat hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta animi dolore.</a>

--- a/test/fixtures/basic/inline-whitespace/input.astro
+++ b/test/fixtures/basic/inline-whitespace/input.astro
@@ -1,1 +1,2 @@
 <a href="/">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eum culpa quaerat hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta animi dolore.</a>
+<a href="/">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eum culpa quaerat hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta animi dolore. </a>

--- a/test/fixtures/basic/inline-whitespace/output.astro
+++ b/test/fixtures/basic/inline-whitespace/output.astro
@@ -1,0 +1,5 @@
+<a href="/"
+  >Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eum culpa quaerat
+  hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta
+  animi dolore.</a
+>

--- a/test/fixtures/basic/inline-whitespace/output.astro
+++ b/test/fixtures/basic/inline-whitespace/output.astro
@@ -3,3 +3,8 @@
   hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta
   animi dolore.</a
 >
+<a href="/"
+  >Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eum culpa quaerat
+  hic voluptas veniam magni sed vero explicabo iste soluta labore totam dicta
+  animi dolore.
+</a>

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -82,7 +82,7 @@ export function test(name: string, files: any, path: string, isMarkdown = false)
 		const opts = getOptions(files, path);
 
 		const formatted = formatFile(input, opts);
-		expect(formatted, 'Incorrect formating').toBe(output);
+		expect(formatted, 'Incorrect formatting').toBe(output);
 
 		// test that our formatting is idempotent
 		const formattedTwice = formatFile(formatted, opts);

--- a/test/tests/basic.test.ts
+++ b/test/tests/basic.test.ts
@@ -17,3 +17,5 @@ test('Can format HTML custom elements', files, 'basic/html-custom-elements');
 test('Can properly format the class attribute', files, 'basic/html-class-attribute');
 
 test('Can format long self-closing tags with multiple attributes', files, 'basic/self-closing');
+
+test('Can properly format inline tags and respect whitespace', files, 'basic/inline-whitespace');


### PR DESCRIPTION
## Changes

Implement end tag hugging for inline elements containing text not ending in whitespace. This was actually already partially implemented, but uncommenting caused another test to fail because it was incorrectly hugging on non-text contents as well.

Also fixed some small typos.

Fixes #263

## Testing

- [x] Added `basic/inline-whitespace` test with cases for both trailing whitespace (should not hug) and no whitespace (should hug)
- [x] Existing `other/fragment` test covers case where we shouldn't hug non-text. I can split out the line that's failing into its own test if desired.

## Docs

- [x] Added changeset
