### PR TITLE
Add support for formatting elements with attributes not compatible with JSX

### DIFF
--- a/.changeset/breezy-bags-matter.md
+++ b/.changeset/breezy-bags-matter.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Support formatting expressions with elements with attributes not compatible with JSX

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -17,6 +17,11 @@ try {
 }
 const serialize = createSyncFn(req.resolve(workerPath));
 
+export const openingBracketReplace = '_Pé';
+export const closingBracketReplace = 'èP_';
+export const atSignReplace = 'ΩP_';
+export const dotReplace = 'ωP_';
+
 export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNode): boolean {
 	return node && node.type === 'element' && !isBlockElement(node, opts) && !isPreTagContent(path);
 }

--- a/test/fixtures/other/non-jsx-compatible-characters/input.astro
+++ b/test/fixtures/other/non-jsx-compatible-characters/input.astro
@@ -1,0 +1,14 @@
+{
+	<div @do={0}>Astro!
+
+
+
+		</div>
+}
+
+{
+	<div do.do={0}>Astro!
+
+
+		</div>
+}

--- a/test/fixtures/other/non-jsx-compatible-characters/output.astro
+++ b/test/fixtures/other/non-jsx-compatible-characters/output.astro
@@ -1,0 +1,3 @@
+{(<div @do={0}>Astro!</div>)}
+
+{(<div do.do={0}>Astro!</div>)}

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -87,3 +87,9 @@ test(
 	files,
 	'other/typescript-expression'
 );
+
+test(
+	'Can format expressions with characters not compatible with JSX',
+	files,
+	'other/non-jsx-compatible-characters'
+);


### PR DESCRIPTION
## Changes

Just like with shorthands props, we need to do some transformations inside expressions to make sure we support things that re valid in Astro but not compatible with JSX. 

## Testing

Added a test

## Docs

N/A
