### PR TITLE
Fix expressions not hugging the end of the tag in cases where it should

### DIFF
--- a/.changeset/pink-jokes-cough.md
+++ b/.changeset/pink-jokes-cough.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix expressions not hugging the end of the tag in cases where they should

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -2,7 +2,15 @@ import { createRequire } from 'node:module';
 import { AstPath as AstP, Doc, ParserOptions as ParserOpts } from 'prettier';
 import { createSyncFn } from 'synckit';
 import { blockElements, formattableAttributes, TagName } from './elements';
-import { anyNode, CommentNode, Node, ParentLikeNode, TagLikeNode, TextNode } from './nodes';
+import {
+	anyNode,
+	CommentNode,
+	ExpressionNode,
+	Node,
+	ParentLikeNode,
+	TagLikeNode,
+	TextNode,
+} from './nodes';
 
 export type printFn = (path: AstPath) => Doc;
 export type ParserOptions = ParserOpts<anyNode>;
@@ -143,6 +151,7 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 	}
 
 	const lastChild = children[children.length - 1];
+	if (isExpressionNode(lastChild)) return true;
 	if (!isTextNode(lastChild)) return false;
 	return !endsWithWhitespace(getUnencodedText(lastChild));
 }
@@ -223,6 +232,10 @@ export function manualDedent(input: string): {
 /** True if the node is of type text */
 export function isTextNode(node: anyNode): node is TextNode {
 	return node.type === 'text';
+}
+
+export function isExpressionNode(node: anyNode): node is ExpressionNode {
+	return node.type === 'expression';
 }
 
 /** True if the node is TagLikeNode:

--- a/test/fixtures/other/expression-in-inline-tag/input.astro
+++ b/test/fixtures/other/expression-in-inline-tag/input.astro
@@ -1,0 +1,3 @@
+<span class="class"
+  >{['long', 'long', 'long', 'long', 'long', 'long', 'long', 'long', 'long', 'long', 'long', 'expression'].join('')
+}</span>

--- a/test/fixtures/other/expression-in-inline-tag/output.astro
+++ b/test/fixtures/other/expression-in-inline-tag/output.astro
@@ -1,0 +1,18 @@
+<span class="class"
+  >{
+    [
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "long",
+      "expression",
+    ].join("")
+  }</span
+>

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -94,3 +94,9 @@ test(
 	files,
 	'other/non-jsx-compatible-characters'
 );
+
+test(
+	'Can format expressions inside inline tags without adding a newline',
+	files,
+	'other/expression-in-inline-tag'
+);


### PR DESCRIPTION
## Changes

Expressions were previously not allowed to hug the end of the tag in any circumstance, this fix that

## Testing

Added a test

## Docs

N/A
