### PR TITLE
Don't add forced hardlines to style tags if the content is empty

### DIFF
--- a/.changeset/silent-kiwis-walk.md
+++ b/.changeset/silent-kiwis-walk.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix newlines being added to style tags even if they were empty

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -228,6 +228,8 @@ function embedStyle(
 	textToDoc: (text: string, options: object) => Doc,
 	options: ParserOptions
 ) {
+	const isEmpty = /^\s*$/.test(content);
+
 	switch (lang) {
 		case 'css':
 		case 'scss': {
@@ -240,7 +242,12 @@ function embedStyle(
 			// print
 			const attributes = path.map(print, 'attributes');
 			const openingTag = group(['<style', indent(group(attributes)), softline, '>']);
-			return [openingTag, indent([hardline, formattedStyles]), hardline, '</style>'];
+			return [
+				openingTag,
+				indent([isEmpty ? '' : hardline, formattedStyles]),
+				isEmpty ? '' : hardline,
+				'</style>',
+			];
 		}
 		case 'sass': {
 			const lineEnding = options.endOfLine.toUpperCase() === 'CRLF' ? 'CRLF' : 'LF';
@@ -260,7 +267,12 @@ function embedStyle(
 			const formattedSass = join(hardline, formattedSassIndented.split('\n'));
 			const attributes = path.map(print, 'attributes');
 			const openingTag = group(['<style', indent(group(attributes)), softline, '>']);
-			return [openingTag, indent(group([hardline, formattedSass])), hardline, '</style>'];
+			return [
+				openingTag,
+				indent([isEmpty ? '' : hardline, formattedSass]),
+				isEmpty ? '' : hardline,
+				'</style>',
+			];
 		}
 	}
 }

--- a/test/fixtures/styles/with-sass/input.astro
+++ b/test/fixtures/styles/with-sass/input.astro
@@ -31,3 +31,8 @@
 
 
 </style>
+
+<style lang="sass" set:html={someCSS}>
+
+
+</style>

--- a/test/fixtures/styles/with-sass/output.astro
+++ b/test/fixtures/styles/with-sass/output.astro
@@ -25,3 +25,5 @@
         padding: 6px 12px
         text-decoration: none
 </style>
+
+<style lang="sass" set:html={someCSS}></style>

--- a/test/fixtures/styles/with-styles/input.astro
+++ b/test/fixtures/styles/with-styles/input.astro
@@ -6,3 +6,5 @@
                 color: red;
 }
 </style>
+
+<style set:html={someCss} />

--- a/test/fixtures/styles/with-styles/output.astro
+++ b/test/fixtures/styles/with-styles/output.astro
@@ -5,3 +5,5 @@
     color: red;
   }
 </style>
+
+<style set:html={someCss}></style>


### PR DESCRIPTION
## Changes

Similarly to a previous fix to script tags, remove forced hardlines if the content of the tag is empty

Fix https://github.com/withastro/prettier-plugin-astro/issues/280

## Testing

Added a test

## Docs

N/A
