### PR TITLE
Add a hardline after attributes on inline elements when using singleAttributePerLine

### DIFF
--- a/.changeset/chilly-donkeys-peel.md
+++ b/.changeset/chilly-donkeys-peel.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix missing newline after attributes on inline elements when using singleAttributePerLine

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -103,8 +103,8 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 			const isSelfClosingTag =
 				isEmpty && (node.type !== 'element' || selfClosingTags.includes(node.name));
 
-			const attributeLine =
-				opts.singleAttributePerLine && node.attributes.length > 1 ? breakParent : '';
+			const isSingleLinePerAttribute = opts.singleAttributePerLine && node.attributes.length > 1;
+			const attributeLine = isSingleLinePerAttribute ? breakParent : '';
 			const attributes = join(attributeLine, path.map(print, 'attributes'));
 
 			if (isSelfClosingTag) {
@@ -139,8 +139,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						isTextNodeStartingWithWhitespace(node.children[0]) &&
 						!isPreTagContent(path)
 							? () => line
-							: // () => (opts.jsxBracketNewLine ? '' : softline);
-							  () => softline;
+							: () => softline;
 				} else if (isPreTagContent(path)) {
 					body = () => printRaw(node);
 				} else if (isInlineElement(path, opts, node) && !isPreTagContent(path)) {
@@ -165,7 +164,10 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 				];
 
 				if (hugStart && hugEnd) {
-					const huggedContent = [softline, group(['>', body(), `</${node.name}`])];
+					const huggedContent = [
+						isSingleLinePerAttribute ? hardline : softline,
+						group(['>', body(), `</${node.name}`]),
+					];
 
 					const omitSoftlineBeforeClosingTag =
 						isEmpty || canOmitSoftlineBeforeClosingTag(path, opts);

--- a/test/fixtures/options/single-attribute-per-line-false/input.astro
+++ b/test/fixtures/options/single-attribute-per-line-false/input.astro
@@ -15,3 +15,4 @@
 }
 )
 }
+<span accesskey="" aria-activedescendant="">s</span>

--- a/test/fixtures/options/single-attribute-per-line-false/output.astro
+++ b/test/fixtures/options/single-attribute-per-line-false/output.astro
@@ -17,3 +17,4 @@
     );
   })
 }
+<span accesskey="" aria-activedescendant="">s</span>

--- a/test/fixtures/options/single-attribute-per-line-true/input.astro
+++ b/test/fixtures/options/single-attribute-per-line-true/input.astro
@@ -15,3 +15,4 @@
 }
 )
 }
+<span accesskey="" aria-activedescendant="">s</span>

--- a/test/fixtures/options/single-attribute-per-line-true/output.astro
+++ b/test/fixtures/options/single-attribute-per-line-true/output.astro
@@ -30,3 +30,8 @@
     );
   })
 }
+<span
+  accesskey=""
+  aria-activedescendant=""
+  >s</span
+>


### PR DESCRIPTION
## Changes

Previously, we were missing a hardline between the attributes and the closing bracket of the opening tag on inline elements when using singleAttributePerLine. This fix that

Fix https://github.com/withastro/prettier-plugin-astro/issues/281

## Testing

Updated tests for this

## Docs

N/A
