### PR TITLE
Allow elements with set:* directives to self-close

### DIFF
--- a/.changeset/warm-dots-type.md
+++ b/.changeset/warm-dots-type.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Allow elements with set:\* directives to self-close

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -6,7 +6,7 @@ import {
 	endsWithLinebreak,
 	getNextNode,
 	getUnencodedText,
-	hasSetAttributes,
+	hasSetDirectives,
 	isEmptyTextNode,
 	isInlineElement,
 	isPreTagContent,
@@ -103,7 +103,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 			}
 			const isSelfClosingTag =
 				isEmpty &&
-				(node.type !== 'element' || selfClosingTags.includes(node.name) || hasSetAttributes(node));
+				(node.type !== 'element' || selfClosingTags.includes(node.name) || hasSetDirectives(node));
 
 			const isSingleLinePerAttribute = opts.singleAttributePerLine && node.attributes.length > 1;
 			const attributeLine = isSingleLinePerAttribute ? breakParent : '';

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -6,6 +6,7 @@ import {
 	endsWithLinebreak,
 	getNextNode,
 	getUnencodedText,
+	hasSetAttributes,
 	isEmptyTextNode,
 	isInlineElement,
 	isPreTagContent,
@@ -101,7 +102,8 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 				isEmpty = node.children.every((child) => isEmptyTextNode(child));
 			}
 			const isSelfClosingTag =
-				isEmpty && (node.type !== 'element' || selfClosingTags.includes(node.name));
+				isEmpty &&
+				(node.type !== 'element' || selfClosingTags.includes(node.name) || hasSetAttributes(node));
 
 			const isSingleLinePerAttribute = opts.singleAttributePerLine && node.attributes.length > 1;
 			const attributeLine = isSingleLinePerAttribute ? breakParent : '';

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -110,6 +110,11 @@ export function isTextNodeEndingWithWhitespace(node: Node): node is TextNode {
 	return isTextNode(node) && endsWithWhitespace(getUnencodedText(node));
 }
 
+export function hasSetAttributes(node: TagLikeNode) {
+	const attributes = Array.from(node.attributes, (attr) => attr.name);
+	return attributes.some((attr) => ['set:html', 'set:text'].includes(attr));
+}
+
 /**
  * Check if given node's start tag should hug its first child. This is the case for inline elements when there's
  * no whitespace between the `>` and the first child.

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -110,7 +110,7 @@ export function isTextNodeEndingWithWhitespace(node: Node): node is TextNode {
 	return isTextNode(node) && endsWithWhitespace(getUnencodedText(node));
 }
 
-export function hasSetAttributes(node: TagLikeNode) {
+export function hasSetDirectives(node: TagLikeNode) {
 	const attributes = Array.from(node.attributes, (attr) => attr.name);
 	return attributes.some((attr) => ['set:html', 'set:text'].includes(attr));
 }

--- a/test/fixtures/other/directive/input.astro
+++ b/test/fixtures/other/directive/input.astro
@@ -3,3 +3,5 @@
 ---
 
     <h1 set:html =  {content  }></h1>
+
+		<Component    set:html =  {content  }></Component>

--- a/test/fixtures/other/directive/output.astro
+++ b/test/fixtures/other/directive/output.astro
@@ -2,4 +2,6 @@
 const content = "lorem";
 ---
 
-<h1 set:html={content}></h1>
+<h1 set:html={content} />
+
+<Component set:html={content} />


### PR DESCRIPTION
## Changes

This PR makes it so any elements that has `set:*` directives can be allowed to self close (provided that it's empty)

## Testing

Updated tests with this

## Docs

N/A