### PR TITLE
Fix jsxSingleQuote not considering the inner quotes like JSX

### DIFF
--- a/.changeset/lucky-cows-applaud.md
+++ b/.changeset/lucky-cows-applaud.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix `jsxSingleQuote` not considering if there was any incompatible characters inside the attribute value

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -5,6 +5,7 @@ import {
 	canOmitSoftlineBeforeClosingTag,
 	endsWithLinebreak,
 	getNextNode,
+	getPreferredQuote,
 	getUnencodedText,
 	hasSetDirectives,
 	isEmptyTextNode,
@@ -247,7 +248,6 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 
 		case 'attribute': {
 			const name = node.name.trim();
-			const quote = opts.jsxSingleQuote ? "'" : '"';
 			switch (node.kind) {
 				case 'empty':
 					return [line, name];
@@ -262,10 +262,14 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						value = printClassNames(value);
 					}
 
-					if (node.name === 'style') {
-					}
+					const unescapedValue = value.replace(/&apos;/g, "'").replace(/&quot;/g, '"');
+					const { escaped, quote, regex } = getPreferredQuote(
+						unescapedValue,
+						opts.jsxSingleQuote ? "'" : '"'
+					);
 
-					return [line, name, '=', quote, value, quote];
+					const result = unescapedValue.replace(regex, escaped);
+					return [line, name, '=', quote, result, quote];
 				case 'shorthand':
 					return [line, '{', name, '}'];
 				case 'spread':

--- a/test/fixtures/options/option-jsx-single-quote-true/input.astro
+++ b/test/fixtures/options/option-jsx-single-quote-true/input.astro
@@ -12,3 +12,5 @@ function hello() {
 <ul class="list">
    {[1, 2, 3].map(value => <li class="list-item">{'hello' + value}</li>)}
  </ul>
+
+<div title="Jake's dog"></div>

--- a/test/fixtures/options/option-jsx-single-quote-true/output.astro
+++ b/test/fixtures/options/option-jsx-single-quote-true/output.astro
@@ -13,3 +13,5 @@ function hello() {
 <ul class='list'>
   {[1, 2, 3].map((value) => <li class='list-item'>{"hello" + value}</li>)}
 </ul>
+
+<div title="Jake's dog"></div>


### PR DESCRIPTION
## Changes

In JSX, `jsxSingleQuote` is only taken into account when the attribute value does not contain any single quotes (and vice versa for double quotes). This makes it so we follow this behaviour too

Fix https://github.com/withastro/prettier-plugin-astro/issues/291

## Testing

Updated test to account for this

## Docs

N/A
