### PR TITLE
Support formatting expressions with multiple roots

### DIFF
--- a/.changeset/clean-games-yawn.md
+++ b/.changeset/clean-games-yawn.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Add support for formatting expressions with multiple root elements

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -35,13 +35,7 @@ export function embed(
 	if (!node) return null;
 
 	if (node.type === 'expression') {
-		let jsxNode: ExpressionNode;
-		try {
-			jsxNode = makeNodeJSXCompatible<ExpressionNode>(node);
-		} catch (e) {
-			process.env.PRETTIER_DEBUG = 'true';
-			throw e;
-		}
+		const jsxNode = makeNodeJSXCompatible<ExpressionNode>(node);
 		const textContent = printRaw(jsxNode);
 
 		let content: Doc;

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -221,8 +221,8 @@ function makeNodeJSXCompatible<T>(node: any): T {
 				}
 
 				if (
-					!nextChildren ||
-					(isTextNode(nextChildren) && childBundle[childBundleIndex].length > 0)
+					(!nextChildren || isTextNode(nextChildren)) &&
+					childBundle[childBundleIndex].length > 0
 				) {
 					childBundle[childBundleIndex].push(child);
 

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -211,6 +211,8 @@ function makeNodeJSXCompatible<T>(node: any): T {
 					child = makeNodeJSXCompatible<typeof child>(child);
 				}
 
+				// If we don't have a previous children, or it's not an element AND
+				// we have a next children, and it's an element. Add the current children to the bundle
 				if (
 					(!previousChildren || isTextNode(previousChildren)) &&
 					nextChildren &&
@@ -220,6 +222,8 @@ function makeNodeJSXCompatible<T>(node: any): T {
 					return result;
 				}
 
+				// If we have elements in our bundle, and there's no next children, or it's a text node
+				// Create a fake parent, and add all the previous encountered elements as children of it
 				if (
 					(!nextChildren || isTextNode(nextChildren)) &&
 					childBundle[childBundleIndex].length > 0

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -198,8 +198,8 @@ function makeNodeJSXCompatible<T>(node: any): T {
 
 	if (isNodeWithChildren(newNode)) {
 		newNode.children = newNode.children.reduce((result: Node[], child, index) => {
-			const previousChildren = newNode.children.at(index - 1);
-			const nextChildren = newNode.children.at(index + 1);
+			const previousChildren = newNode.children[index - 1];
+			const nextChildren = newNode.children[index + 1];
 			if (isTagLikeNode(child)) {
 				child.attributes = child.attributes.map(makeAttributeJSXCompatible);
 

--- a/test/fixtures/other/expression-multiple-roots/input.astro
+++ b/test/fixtures/other/expression-multiple-roots/input.astro
@@ -1,0 +1,11 @@
+{hello ?? <div></div><div></div>}
+
+{hello ? <div></div><div></div> : <span></span><span></span>}
+
+{[].map((value) => <div>{value}</div><h1>{value}</h1>)}
+
+{[].map((value) => {
+	console.log(value);
+
+	return <div></div><h1></h1>
+})}

--- a/test/fixtures/other/expression-multiple-roots/output.astro
+++ b/test/fixtures/other/expression-multiple-roots/output.astro
@@ -1,0 +1,44 @@
+{
+  hello ?? (
+    <>
+      <div />
+      <div />
+    </>
+  )
+}
+
+{
+  hello ? (
+    <>
+      <div />
+      <div />
+    </>
+  ) : (
+    <>
+      <span />
+      <span />
+    </>
+  )
+}
+
+{
+  [].map((value) => (
+    <>
+      <div>{value}</div>
+      <h1>{value}</h1>
+    </>
+  ))
+}
+
+{
+  [].map((value) => {
+    console.log(value);
+
+    return (
+      <>
+        <div />
+        <h1 />
+      </>
+    );
+  })
+}

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -100,3 +100,9 @@ test(
 	files,
 	'other/expression-in-inline-tag'
 );
+
+test(
+	'Can format expressions who have multi-roots returns',
+	files,
+	'other/expression-multiple-roots'
+);


### PR DESCRIPTION
## Changes

This is a bit of a Not Worst Than What We Had Before situation, as I found a way to correct the expressions so they can be parsed by Prettier's JavaScript parsers, however I couldn't figure out a way to "uncorrect" them so they're "Astro-like".

I tried a bunch of things, but they had all downsides such as the indentation being wrong, not working in some cases, messing up the formatting somewhere else etc.

In my opinion, it formatting clumsily in a consistant way is better than it crashing and failing to format the entire file. So, hey, it's an improvement

Fix https://github.com/withastro/prettier-plugin-astro/issues/238

### Preview

Before
```astro
{hello ?? <div></div><div></div>}
```

After
```astro
{
  hello ?? (
    <>
      <div />
      <div />
    </>
  )
}
```

## Testing

Added a test for this

## Docs

N/A
