### PR TITLE
Don't allow custom-elements to self close

### DIFF
--- a/.changeset/tiny-parents-refuse.md
+++ b/.changeset/tiny-parents-refuse.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Fixed custom-elements being allowed to self close despite the HTML spec saying otherwise

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -102,9 +102,19 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 			} else {
 				isEmpty = node.children.every((child) => isEmptyTextNode(child));
 			}
+
+			/**
+			 * An element is allowed to self close only if:
+			 * It is empty AND
+			 *  It's a component OR
+			 *  It's in the HTML spec as a void element OR
+			 *  It has a `set:*` directive
+			 */
 			const isSelfClosingTag =
 				isEmpty &&
-				(node.type !== 'element' || selfClosingTags.includes(node.name) || hasSetDirectives(node));
+				(node.type === 'component' ||
+					selfClosingTags.includes(node.name) ||
+					hasSetDirectives(node));
 
 			const isSingleLinePerAttribute = opts.singleAttributePerLine && node.attributes.length > 1;
 			const attributeLine = isSingleLinePerAttribute ? breakParent : '';

--- a/test/fixtures/basic/html-custom-elements/output.astro
+++ b/test/fixtures/basic/html-custom-elements/output.astro
@@ -1,1 +1,1 @@
-<custom-element />
+<custom-element></custom-element>


### PR DESCRIPTION
## Changes

Thank you @getflourish for reporting this issue!

According to the HTML Spec, custom elements are not allowed to self-close

In Astro it doesn't really matter, since the compiler will self close them anyway, but as a formatter we generally try to output compliant HTML (also this is how it is in other Prettier plugin, so might as well be consistent)

Similarly to other tags that are traditionally not able to self close, adding a `set:*` directive will allow them to self close even then

## Testing

Updated tests

## Docs

N/A
