### PR TITLE
yarn: pin to latest v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
     "tslib": "^2.4.0",
     "typescript": "^4.8.4",
     "vitest": "^0.24.3"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
## Changes

- Pins Yarn to `1.22.19` ([latest v1](https://github.com/yarnpkg/yarn/releases))
- Generated by running `yarn set version 1.22.19`
- Without this, running `yarn` (as suggested in `CONTRIBUTING.md`) with a v2+ version of Yarn (I was using `3.2.3`) results in Yarn thinking it should upgrade the repo to Yarn v2+.
- Yarn also created `.yarn/releases/yarn-1.22.19.cjs` (4.9 MB node module), and `.yarnrc` with the following contents:

```cjs
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


yarn-path ".yarn/releases/yarn-1.22.19.cjs"
```

- I did not include these two files in this PR, as they do not seem to be required. There may be advantages to adding them, happy to do so if others think it best.
- Huh, sometimes (maybe when `.yarnrc` already exists?) it will create `.yarnrc.yml` with the following contents:
```yaml
yarnPath: .yarn/releases/yarn-1.22.19.cjs
```
... Which seems a tiny bit nicer. 🤷

## Testing

Ran various commands in `CONTRIBUTING.md` (`yarn`, `yarn build`, `yarn test`, `yarn lint`, `yarn format`), everything looked good.

Tested with `node` `v18.11.0` (macOS).

## Docs

I considered adding something to `CONTRIBUTING.md` to make it obvious that this repo uses Yarn v1, happy to do so. Would be nice to also mention which version(s) of Node are supported.