### PR TITLE
Bump `@astrojs/compiler` to `0.29.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "release": "yarn build && changeset publish"
   },
   "dependencies": {
-    "@astrojs/compiler": "0.27.2",
+    "@astrojs/compiler": "0.29.1",
     "prettier": "^2.7.1",
     "sass-formatter": "^0.7.5",
     "synckit": "^0.8.4"
@@ -61,5 +61,6 @@
     "tslib": "^2.4.0",
     "typescript": "^4.8.4",
     "vitest": "^0.24.3"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
## Changes

- Update `@astrojs/compiler` to [`0.29.1`](https://github.com/withastro/compiler/releases/tag/%40astrojs%2Fcompiler%400.29.1) (was at [`0.27.2`](https://github.com/withastro/compiler/releases/tag/%40astrojs%2Fcompiler%400.27.2))
- Diff: [Comparing @astrojs/compiler@0.27.2...@astrojs/compiler@0.29.1 · withastro/compiler](https://github.com/withastro/compiler/compare/%40astrojs%2Fcompiler%400.27.2...%40astrojs/compiler%400.29.1)
- Fixes #295

## Testing

No new tests needed.

`yarn && yarn build && yarn test && yarn lint && yarn format` output looked good.

## Docs

n/a