### PR TITLE
chore: use .cjs instead of .js

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When submitting issues about formatting in VS Code, first make sure you're actua
 
 Due to an upstream issue, Prettier inside VS Code isn't able to automatically infer the right parser to use for Astro files when using pnpm
 
-As such, add the following settings to your `.prettierrc.js` config file:
+As such, add the following settings to your `.prettierrc.cjs` config file:
 
 ```js
 module.exports = {
@@ -84,7 +84,7 @@ Set if attributes with the same name as their expression should be formatted to 
 | ------- | -------------------------------- | ----------------------------- |
 | `false` | `--astro-allow-shorthand <bool>` | `astroAllowShorthand: <bool>` |
 
-### Example `.prettierrc.js`
+### Example `.prettierrc.cjs`
 
 ```js
 {


### PR DESCRIPTION
## Changes

- What does this change?
File extension using for Prettier config file.

## Testing

I tried to use Prettier to format a .astro file on VS Code and this was the output:
```sh
["INFO" - 3:25:28 AM] Formatting file:///Users/guilherme/workspace/personal/digital-garden/src/components/Card.astro
["ERROR" - 3:25:28 AM] Error resolving prettier configuration for /Users/guilherme/workspace/personal/digital-garden/src/components/Card.astro
["ERROR" - 3:25:28 AM] require() of ES Module /Users/guilherme/workspace/personal/digital-garden/.prettierrc.js from /Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js not supported.
.prettierrc.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename .prettierrc.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/guilherme/workspace/personal/digital-garden/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/guilherme/workspace/personal/digital-garden/.prettierrc.js from /Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js not supported.
.prettierrc.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename .prettierrc.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/guilherme/workspace/personal/digital-garden/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at a._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:118:14563)
    at v._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:113:64900)
    at w._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:113:64268)
    at module2.exports (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:83:61)
    at loadJs2 (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8050:22)
    at Explorer.loadFileContent (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8449:36)
    at Explorer.createCosmiconfigResult (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8453:40)
    at Explorer.loadSearchPlace (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8438:35)
    at async Explorer.searchDirectory (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8428:31)
    at async run (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8413:26)
    at async Explorer.search (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/third-party.js:8407:24)
    at async Object.resolveConfigFile (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/node_modules/prettier/index.js:18280:22)
    at async t.ModuleResolver.getResolvedConfig (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/dist/extension.js:1:5402)
    at async t.default.format (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/dist/extension.js:1:13142)
    at async t.PrettierEditProvider.provideEdits (/Users/guilherme/.vscode/extensions/esbenp.prettier-vscode-9.9.0/dist/extension.js:1:11259)
    at async B.provideDocumentFormattingEdits (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:94:45902)
```

## Docs

The docs were update accordingly.
