### PR TITLE
Fix node not hugging their end when the last children was a node

### DIFF
--- a/.changeset/mighty-boats-bow.md
+++ b/.changeset/mighty-boats-bow.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix inline tags not hugging the end of their content if the last child was a tag

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  // Make sure fixtures don't get formatted by accident while working on them
+  "[astro]": {
+    "editor.formatOnSave": false,
+    "editor.formatOnPaste": false,
+    "editor.formatOnType": false
+  }
+}

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -128,6 +128,10 @@ export function shouldHugStart(node: anyNode, opts: ParserOptions): boolean {
 		return false;
 	}
 
+	if (node.type === 'fragment') {
+		return false;
+	}
+
 	if (!isNodeWithChildren(node)) {
 		return false;
 	}
@@ -150,6 +154,10 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 		return false;
 	}
 
+	if (node.type === 'fragment') {
+		return false;
+	}
+
 	if (!isNodeWithChildren(node)) {
 		return false;
 	}
@@ -161,6 +169,7 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 
 	const lastChild = children[children.length - 1];
 	if (isExpressionNode(lastChild)) return true;
+	if (isTagLikeNode(lastChild)) return true;
 	if (!isTextNode(lastChild)) return false;
 	return !endsWithWhitespace(getUnencodedText(lastChild));
 }

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -36,10 +36,13 @@ export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNod
 
 export function isBlockElement(node: anyNode, opts: ParserOptions): boolean {
 	return (
-		node &&
-		node.type === 'element' &&
-		opts.htmlWhitespaceSensitivity !== 'strict' &&
-		(opts.htmlWhitespaceSensitivity === 'ignore' || blockElements.includes(node.name as TagName))
+		(node &&
+			node.type === 'element' &&
+			opts.htmlWhitespaceSensitivity !== 'strict' &&
+			(opts.htmlWhitespaceSensitivity === 'ignore' ||
+				blockElements.includes(node.name as TagName))) ||
+		node.type === 'component' ||
+		node.type === 'fragment'
 	);
 }
 
@@ -154,10 +157,6 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 		return false;
 	}
 
-	if (node.type === 'fragment') {
-		return false;
-	}
-
 	if (!isNodeWithChildren(node)) {
 		return false;
 	}
@@ -170,8 +169,7 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 	const lastChild = children[children.length - 1];
 	if (isExpressionNode(lastChild)) return true;
 	if (isTagLikeNode(lastChild)) return true;
-	if (!isTextNode(lastChild)) return false;
-	return !endsWithWhitespace(getUnencodedText(lastChild));
+	return !isTextNodeEndingWithWhitespace(lastChild);
 }
 
 /**

--- a/test/fixtures/other/hugging/input.astro
+++ b/test/fixtures/other/hugging/input.astro
@@ -1,0 +1,2 @@
+<p>
+	<a href="#">If the text is longer than the line length for Prettier to start wrapping, this is... <span>not fine</span></a>.</p>

--- a/test/fixtures/other/hugging/output.astro
+++ b/test/fixtures/other/hugging/output.astro
@@ -1,0 +1,6 @@
+<p>
+  <a href="#"
+    >If the text is longer than the line length for Prettier to start wrapping,
+    this is... <span>not fine</span></a
+  >.
+</p>


### PR DESCRIPTION
## Changes

Previously, we'd only specially case not hugging if the last child of a node was an expression, this PR also makes it so we forcefully hug if the last node is a tag, but only for non-components and fragments, as those are still considered block elements

Hugging rules are slightly confusing, eh

Fix #309

## Testing

Added test

## Docs

N/A
