### PR TITLE
fix(css): Add support for formatting LESS style blocks

### DIFF
--- a/.changeset/clever-planes-try.md
+++ b/.changeset/clever-planes-try.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Add support for LESS style tags, fixed crash on style tags with unknown languages

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -275,7 +275,7 @@ function embedStyle(
 	print: printFn,
 	textToDoc: (text: string, options: object) => Doc,
 	options: ParserOptions
-) {
+): Doc | null {
 	const isEmpty = /^\s*$/.test(content);
 
 	switch (lang) {
@@ -329,6 +329,8 @@ function embedStyle(
 			if (node) {
 				return options.originalText.slice(options.locStart(node), options.locEnd(node));
 			}
+
+			return null;
 		}
 	}
 }

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -138,10 +138,6 @@ export function embed(
 			}
 		}
 
-		if (!parserLang) {
-			return null;
-		}
-
 		return embedStyle(parserLang, content, path, print, textToDoc, opts);
 	}
 
@@ -273,7 +269,7 @@ function makeNodeJSXCompatible<T>(node: any): T {
  * Format the content of a style tag and print the entire element
  */
 function embedStyle(
-	lang: supportedStyleLang,
+	lang: supportedStyleLang | undefined,
 	content: string,
 	path: AstPath,
 	print: printFn,
@@ -326,6 +322,13 @@ function embedStyle(
 				isEmpty ? '' : hardline,
 				'</style>',
 			];
+		}
+		case undefined: {
+			const node = path.getNode();
+
+			if (node) {
+				return options.originalText.slice(options.locStart(node), options.locEnd(node));
+			}
 		}
 	}
 }

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -149,6 +149,11 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 				return group(['<', node.name, indent(attributes), line, `/>`]);
 			}
 
+			// If we're somehow here on a style or script tag, it means embed couldn't handle it. Just return as-is
+			if (['style', 'script'].includes(node.name)) {
+				return opts.originalText.slice(opts.locStart(node), opts.locEnd(node));
+			}
+
 			if (node.children) {
 				const children = node.children;
 				const firstChild = children[0];

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -149,11 +149,6 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 				return group(['<', node.name, indent(attributes), line, `/>`]);
 			}
 
-			// If we're somehow here on a style or script tag, it means embed couldn't handle it. Just return as-is
-			if (['style', 'script'].includes(node.name)) {
-				return opts.originalText.slice(opts.locStart(node), opts.locEnd(node));
-			}
-
 			if (node.children) {
 				const children = node.children;
 				const firstChild = children[0];

--- a/test/fixtures/styles/with-less/input.astro
+++ b/test/fixtures/styles/with-less/input.astro
@@ -1,0 +1,9 @@
+<style lang="less">
+	@width: 10px;
+@height: @width + 10px;
+
+#header {
+  width: @width;
+  height: @height;
+}
+</style>

--- a/test/fixtures/styles/with-less/output.astro
+++ b/test/fixtures/styles/with-less/output.astro
@@ -1,0 +1,9 @@
+<style lang="less">
+  @width: 10px;
+  @height: @width + 10px;
+
+  #header {
+    width: @width;
+    height: @height;
+  }
+</style>

--- a/test/fixtures/styles/with-styles-and-body-tag/output.astro
+++ b/test/fixtures/styles/with-styles-and-body-tag/output.astro
@@ -7,7 +7,6 @@
     <h1>This is a heading</h1>
     <p>This is a paragraph.</p>
   </body>
-
 </html>
 
 <style>

--- a/test/fixtures/styles/with-unknown/input.astro
+++ b/test/fixtures/styles/with-unknown/input.astro
@@ -1,0 +1,9 @@
+<style lang="wacky-new-css">
+		%var: width: 10px;
+		%var: height: @width + 10px;
+
+#header {
+  width: @width;
+  			height: @height;
+}
+</style>

--- a/test/fixtures/styles/with-unknown/output.astro
+++ b/test/fixtures/styles/with-unknown/output.astro
@@ -1,0 +1,9 @@
+<style lang="wacky-new-css">
+		%var: width: 10px;
+		%var: height: @width + 10px;
+
+#header {
+  width: @width;
+  			height: @height;
+}
+</style>

--- a/test/tests/styles.test.ts
+++ b/test/tests/styles.test.ts
@@ -31,9 +31,12 @@ test(
 	'styles/format-nested-sass-style-tag-content'
 );
 
-// TODO: needs to fix in the compiler
-// test(
-//   'Can format a basic Astro file with styles and a body tag',
-//   files,
-//   'styles/with-styles-and-body-tag'
-// );
+test(
+	'Can format a basic Astro file with styles and a body tag',
+	files,
+	'styles/with-styles-and-body-tag'
+);
+
+test('Can format .less styles', files, 'styles/with-less');
+
+test('does not format unknown CSS languages', files, 'styles/with-unknown');


### PR DESCRIPTION
## Changes

It turns out that Prettier support LESS, so we can format those code blocks as well. Nice!

This PR also makes it so we ignore style blocks we don't understand, as previously we'd crash on them

Fix https://github.com/withastro/prettier-plugin-astro/issues/317

## Testing

Added tests for this. Also re-enabled an old disabled test that was disabled due to a compiler isu

## Docs

N/A
