### PR TITLE
fix: treat offset as bytes

### DIFF
--- a/.changeset/silent-apricots-sniff.md
+++ b/.changeset/silent-apricots-sniff.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix style tags using Stylus being truncated under certain circumstances

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'rollup';
 export default defineConfig({
 	input: 'src/index.ts',
 	plugins: [commonjs(), typescript()],
-	external: ['prettier', 'prettier/doc', 'synckit', 'sass-formatter', 'node:module'],
+	external: ['prettier', 'prettier/doc', 'synckit', 'sass-formatter', 'node:module', 'node:buffer'],
 	output: {
 		dir: 'dist',
 		format: 'cjs',

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { BuiltInParsers, Doc, ParserOptions } from 'prettier';
 import _doc from 'prettier/doc';
 import { SassFormatter, SassFormatterConfig } from 'sass-formatter';
@@ -336,7 +337,9 @@ function embedStyle(
 			const node = path.getNode();
 
 			if (node) {
-				return options.originalText.slice(options.locStart(node), options.locEnd(node));
+				return Buffer.from(options.originalText)
+					.subarray(options.locStart(node), options.locEnd(node))
+					.toString();
 			}
 
 			return null;

--- a/test/fixtures/styles/with-unknown/input.astro
+++ b/test/fixtures/styles/with-unknown/input.astro
@@ -1,3 +1,5 @@
+<b>❤️</b>
+
 <style lang="wacky-new-css">
 		%var: width: 10px;
 		%var: height: @width + 10px;

--- a/test/fixtures/styles/with-unknown/output.astro
+++ b/test/fixtures/styles/with-unknown/output.astro
@@ -1,3 +1,5 @@
+<b>❤️</b>
+
 <style lang="wacky-new-css">
 		%var: width: 10px;
 		%var: height: @width + 10px;


### PR DESCRIPTION
## Changes
Fixes #323.
Uses `Buffer` to correctly locate an AST node.

## Testing

Complements the test case of unknown style preprocessor with a template which contains special characters, thus it won't pass without the changes in this PR.

## Docs

Bug fix only.
