### PR TITLE
Respect Prettier's behaviour for self closing elements

### DIFF
--- a/.changeset/rich-keys-bake.md
+++ b/.changeset/rich-keys-bake.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Updated self-closing behaviour to be more in line with Prettier's HTML formatter

--- a/src/printer/elements.ts
+++ b/src/printer/elements.ts
@@ -1,31 +1,50 @@
-export type TagName = keyof HTMLElementTagNameMap | 'svg';
+export type TagName = keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap;
 
-// https://github.com/prettier/prettier/blob/main/vendors/html-void-elements.json
-export const selfClosingTags = [
+export const selfClosingTags: TagName[] = [
 	'area',
 	'base',
-	'basefont',
-	'bgsound',
 	'br',
 	'col',
-	'command',
 	'embed',
-	'frame',
 	'hr',
 	'image',
 	'img',
 	'input',
-	'isindex',
-	'keygen',
 	'link',
-	'menuitem',
 	'meta',
-	'nextid',
-	'param',
 	'slot',
 	'source',
 	'track',
 	'wbr',
+
+	// The SVG spec doesn't really have a concept of void elements, everything is allowed
+	// However, some tags are very commonly self-closed by users, and as such they find it confusing for them to not be closed
+	'circle',
+	'ellipse',
+	'line',
+	'path',
+	'polygon',
+	'polyline',
+	'rect',
+	'stop',
+	'use',
+
+	// Filters
+	'feBlend',
+	'feColorMatrix',
+	'feComponentTransfer',
+	'feComposite',
+	'feConvolveMatrix',
+	'feDiffuseLighting',
+	'feDisplacementMap',
+	'feFlood',
+	'feGaussianBlur',
+	'feMerge',
+	'feMorphology',
+	'feOffset',
+	'feSpecularLighting',
+	'feTile',
+	'feTurbulence',
 ];
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#Elements

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -1,5 +1,5 @@
 import { Doc } from 'prettier';
-import { selfClosingTags } from './elements';
+import { selfClosingTags, type TagName } from './elements';
 import { TextNode } from './nodes';
 import {
 	AstPath,
@@ -130,16 +130,18 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 
 			/**
 			 * An element is allowed to self close only if:
+			 * It's already self-closing OR
 			 * It is empty AND
 			 *  It's a component OR
 			 *  It's in the HTML spec as a void element OR
 			 *  It has a `set:*` directive
 			 */
 			const isSelfClosingTag =
-				isEmpty &&
-				(node.type === 'component' ||
-					selfClosingTags.includes(node.name) ||
-					hasSetDirectives(node));
+				(node.position?.end && opts.originalText.at(opts.locEnd(node) - 1) == '/') ||
+				(isEmpty &&
+					(node.type === 'component' ||
+						selfClosingTags.includes(node.name as TagName) ||
+						hasSetDirectives(node)));
 
 			const isSingleLinePerAttribute = opts.singleAttributePerLine && node.attributes.length > 1;
 			const attributeLine = isSingleLinePerAttribute ? breakParent : '';


### PR DESCRIPTION
## Changes

> Blocked by https://github.com/withastro/compiler/issues/716

Prettier has a.. interesting behaviour regarding self-closing in that.. it doesn't actually respect the HTML spec...

Instead, [it'll use whatever the user specified](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4AID0AfCADQgQAOMm0AzsqAIYBOzEA7gAosL0qMAbdowCe9MgCNmjMAGs4MAMqMAtnAAymKHGQAzQbTiTpchYooytAc2QxmAVyMg4KiXHTp36xlCv3GVnAAYhDMKoww1L7IIIz2MBCkIAAWMCoCAOrJmPC0FmBwirw5ODkiMWC04iBahswwnNJW4XoGTgBWtAAeitYCcACK9hDwrQKGZBbMdTGp6UkUzFowGZjoMMnIABwADJNshhnSFDGLcHXYOmQAjsPwjZR8sbQAtNru7knMcLeY340BFpIfTjJyGFSYWwOMF9OAAQUiSwk8TgnDgzE02jGExAtFhQxGOmBbTIMEYElW602SAATKTpJgBNYAMIQFRA5y0ACsSXshgAKuS+CCcdhHABJKCeWCKMBLKhwqWKGAifrYuAAXw1QA) (so, `<div />` will stay as is, despite being invalid HTML) unless [the user hasn't explicitly closed the tag](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4D4QA0IEADjJtAM7KgCGATvRAO4AKDC1KtANs7QE9qRAEb1aYANZwYAZVoBbOABlMUOMgBmvSnFHipM2SQlqA5shj0ArnpBwFIuOnTPltKGeu0zcAGIQ9Aq0MOSeyCC01jAQhCAAFjAKPADq8ZjwlCZgcLKcGTgZAhFglMIgarr0MKziZsFaOnYAVpQAHrLmPHAAitYQ8I08ukQm9FURiclxJPRqMCmY6DDxyAAcAAyjTLop4iQRs3BV2BpEAI798LWkXJGUALTqzs5x9HCXmO+1Pg1I2sM7LoFJhLDYgV04ABBUJzETROCsOD0VTqIYjECUSF9AYaf5NIgwWgiRbLVZIABMhPEmB45gAwhAFH97JQAKxxay6AAqxK4AIx2FsAEkoK5YLIwHMyFCxbIYAJuui4ABfFVAA) (ex: `<div>`), in which case [it'll do whatever the spec says](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAtnGBDAfCAGhAgAcYBLaAZ2VGwCd6IB3ABQYRpWwBtnsAnjSIAjetjABrLAGVsmADLkocZADNeVOKPFTZJCcoDmyGPQCu2kHHQi4AE3sOF2KEfPYjcAGIR66bBgKN2QQbHMYCEIQAAsYdB4AdRjyeCoDMDgZTlTyADdUgVCwKmEQZS16GFZxIwD1TSsAKyoADxljHjgARXMIeAaeLSIDekrQuIToknplGETyexgY5AAOAAYRpi1E8RJQmbhKvNUiAEc++BrSLjCqAFoVBwdo+jgL8jeaz3qkDSGrFp0ORTBZAZ04ABBIKzEQROCsOD0JQqQbDEBUCG9fqqP6NIg4EQLJYrJAAJgJ4nIPGMAGEIOhftYqABWaLmLQAFWwIi4-3ReUsAEkoE5YDIwLMyJDRTIYAIumi4ABfZVAA).

Very confusing, but even more so confusing for users used to the behaviour Prettier usually has. This PR makes it so it follows Prettier's behavior.

Fix https://github.com/withastro/prettier-plugin-astro/issues/325

## Testing

Tests already cover this!

## Docs

N/A
