### PR TITLE
1.0 release!

### DIFF
--- a/.changeset/fair-parents-grow.md
+++ b/.changeset/fair-parents-grow.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': major
+---
+
+Symbolic 1.0 release! With many big projects using the Prettier plugin succesfully, we now consider it stable enough to warrant the 1.0 version.


### PR DESCRIPTION
## Changes

**Blocked by the following compiler issues:**
- https://github.com/withastro/compiler/issues/712
- https://github.com/withastro/compiler/issues/716 (blocking https://github.com/withastro/prettier-plugin-astro/pull/328)

---

This is the symbolic "Press to merge" release for the 1.0 of the Prettier plugin. We only rarely receive issues and complaints about this project, and many fairly big projects use it successfully everyday. As such, we consider it to be 1.0 ready 🥳

Much like Prettier itself does not follow semver, this project won't (every small bug fix in a formatter is breaking, there's no ways around it). So this is very mostly symbolic

## What about X?

**On https://github.com/withastro/prettier-plugin-astro/issues/308**

This issue is unfortunately a veritable headache to fix at the moment. It's definitely a major bug, but we consider the plugin to still be usable without it, especially since there's possible workarounds available. 

## Testing

N/A

## Docs

N/A