### PR TITLE
Add compatibility for other plugins parsing top-level returns in Astro frontmatter

### DIFF
--- a/.changeset/four-rabbits-destroy.md
+++ b/.changeset/four-rabbits-destroy.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Add compatibility for other plugins parsing top-level returns in Astro frontmatter

--- a/test/fixtures/return/return-arrow-parens-avoid/input.astro
+++ b/test/fixtures/return/return-arrow-parens-avoid/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-arrow-parens-avoid/options.json
+++ b/test/fixtures/return/return-arrow-parens-avoid/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+}

--- a/test/fixtures/return/return-arrow-parens-avoid/output.astro
+++ b/test/fixtures/return/return-arrow-parens-avoid/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return";
+
+// Test 3: we can use return in a function
+function t() {
+  return "return";
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return";
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-basic/input.astro
+++ b/test/fixtures/return/return-basic/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-basic/options.json
+++ b/test/fixtures/return/return-basic/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-basic/output.astro
+++ b/test/fixtures/return/return-basic/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return";
+
+// Test 3: we can use return in a function
+function t() {
+  return "return";
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return";
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-bracket-spacing-false/input.astro
+++ b/test/fixtures/return/return-bracket-spacing-false/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-bracket-spacing-false/options.json
+++ b/test/fixtures/return/return-bracket-spacing-false/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": false,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-bracket-spacing-false/output.astro
+++ b/test/fixtures/return/return-bracket-spacing-false/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return";
+
+// Test 3: we can use return in a function
+function t() {
+  return "return";
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return";
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-semicolon-false/input.astro
+++ b/test/fixtures/return/return-semicolon-false/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-semicolon-false/options.json
+++ b/test/fixtures/return/return-semicolon-false/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-semicolon-false/output.astro
+++ b/test/fixtures/return/return-semicolon-false/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return"
+
+// Test 3: we can use return in a function
+function t() {
+  return "return"
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return"
+}
+
+// Test 5: we can use return outside a block
+return `return`
+
+// Test 6: we can return multiple things
+return (1, 2 as const)
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-single-quote-true/input.astro
+++ b/test/fixtures/return/return-single-quote-true/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-single-quote-true/options.json
+++ b/test/fixtures/return/return-single-quote-true/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-single-quote-true/output.astro
+++ b/test/fixtures/return/return-single-quote-true/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from 'return';
+
+// Test 3: we can use return in a function
+function t() {
+  return 'return';
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return 'return';
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-trailing-comma-all/input.astro
+++ b/test/fixtures/return/return-trailing-comma-all/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-all/options.json
+++ b/test/fixtures/return/return-trailing-comma-all/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-trailing-comma-all/output.astro
+++ b/test/fixtures/return/return-trailing-comma-all/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return";
+
+// Test 3: we can use return in a function
+function t() {
+  return "return";
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return";
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/fixtures/return/return-trailing-comma-none/input.astro
+++ b/test/fixtures/return/return-trailing-comma-none/input.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+  // return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+  import _return from 'return'
+
+// Test 3: we can use return in a function
+  function t() {
+    ;return "return"
+  }
+
+// Test 4: we can use return in a block
+  if (false) {
+    return 'return';
+  }
+
+// Test 5: we can use return outside a block
+  return `return`
+
+// Test 6: we can return multiple things
+  return 1, 2 as const
+---
+
+<!-- Test 7: we can use return in HTML -->
+  <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-none/options.json
+++ b/test/fixtures/return/return-trailing-comma-none/options.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/test/fixtures/return/return-trailing-comma-none/output.astro
+++ b/test/fixtures/return/return-trailing-comma-none/output.astro
@@ -1,0 +1,26 @@
+---
+// Test 1: we can use the word return in a comment without problems
+// return "return" 'return' ;return
+
+// Test 2: we can use return in an import
+import _return from "return";
+
+// Test 3: we can use return in a function
+function t() {
+  return "return";
+}
+
+// Test 4: we can use return in a block
+if (false) {
+  return "return";
+}
+
+// Test 5: we can use return outside a block
+return `return`;
+
+// Test 6: we can return multiple things
+return (1, 2 as const);
+---
+
+<!-- Test 7: we can use return in HTML -->
+<div>return</div>

--- a/test/tests/return.test.ts
+++ b/test/tests/return.test.ts
@@ -1,0 +1,44 @@
+import { test } from '../test-utils';
+
+const files = import.meta.glob('/test/fixtures/return/*/*', {
+	eager: true,
+	as: 'raw',
+});
+
+test('Can format an Astro file with top-level return', files, 'return/return-basic');
+
+test(
+	'Can format an Astro file with top-level return with prettier "semi: false" option',
+	files,
+	'return/return-semicolon-false'
+);
+
+test(
+	'Can format an Astro file with top-level return with prettier "singleQuote: true" option',
+	files,
+	'return/return-single-quote-true'
+);
+
+test(
+	'Can format an Astro file with top-level return with prettier "trailingComma: all" option',
+	files,
+	'return/return-trailing-comma-all'
+);
+
+test(
+	'Can format an Astro file with top-level return with prettier "trailingComma: none" option',
+	files,
+	'return/return-trailing-comma-none'
+);
+
+test(
+	'Can format an Astro file with top-level return with prettier "bracketSpacing: false" option',
+	files,
+	'return/return-bracket-spacing-false'
+);
+
+test(
+	'Can format an Astro file with top-level return with prettier "arrowParens: avoid" option',
+	files,
+	'return/return-arrow-parens-avoid'
+);


### PR DESCRIPTION
## Changes

Fixes #326 

Before, prettier-plugin-astro would pass frontmatter as-is to prettier's typescript formatter. This would break plugins that parse the typescript if there are any top-level returns in the frontmatter, as top-level returns are not valid javascript.

This change 
- adds a marker before all `return` statements in Astro frontmatter
- changes `return` to `throw`
- runs the typescript prettier on the modified frontmatter
- finds the marker to turn the `throw`s back to `return`s
- removes the marker
- cleans up any comments that were modified
 
It's a pretty ugly hack and I'm not proud of it, but it seemingly gets the job done. I expect there is some input on which it will break horribly.

As a note, I did try using a comment as a marker but that breaks if a user uses "return" as a word in comments, which is very likely. I also tried putting the marker after the `return` instead of before, but found that it changed the formatted output in a way that is hard to safely reverse.

## Testing

I ran the existing tests. I also tested it on a variety of input and options manually with the `@trivago/prettier-plugin-sort-imports` plugin enabled to ensure the transforms worked as expected.

I did not add any tests for this feature as I wanted to first verify this feature is desired. If you like the idea and want me to add tests I would be happy to do so.

## Docs

No docs were updated as this is a compatibility fix and should not affect how end-users use the plugin.
