### PR TITLE
Use `babel-ts` to parse the frontmatter

### DIFF
--- a/.changeset/brown-roses-divide.md
+++ b/.changeset/brown-roses-divide.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Use the babel-ts parser to parse the frontmatter. This parser was already used for expressions inside the template, so the experience should now be more homogenous all throughout the file.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "[astro]": {
     "editor.formatOnSave": false,
     "editor.formatOnPaste": false,
-    "editor.formatOnType": false
+    "editor.formatOnType": false,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false
+    }
   }
 }

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -171,6 +171,8 @@ function wrapParserTryCatch(
 }
 
 function expressionParser(text: string, parsers: BuiltInParsers, options: ParserOptions) {
+// note the trailing newline: if the statement ends in a // comment, 
+// we can't add the closing bracket right afterwards
 	const expressionContent = `<>{${text}\n}</>`;
 
 	// @ts-ignore

--- a/test/fixtures/return/return-arrow-parens-avoid/input.astro
+++ b/test/fixtures/return/return-arrow-parens-avoid/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-arrow-parens-avoid/output.astro
+++ b/test/fixtures/return/return-arrow-parens-avoid/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-basic/input.astro
+++ b/test/fixtures/return/return-basic/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-basic/output.astro
+++ b/test/fixtures/return/return-basic/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-bracket-spacing-false/input.astro
+++ b/test/fixtures/return/return-bracket-spacing-false/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-bracket-spacing-false/output.astro
+++ b/test/fixtures/return/return-bracket-spacing-false/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-semicolon-false/input.astro
+++ b/test/fixtures/return/return-semicolon-false/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-semicolon-false/output.astro
+++ b/test/fixtures/return/return-semicolon-false/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`
 
 // Test 6: we can return multiple things
-return (1, 2 as const)
+return 1, 2 as const
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/")
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-single-quote-true/input.astro
+++ b/test/fixtures/return/return-single-quote-true/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-single-quote-true/output.astro
+++ b/test/fixtures/return/return-single-quote-true/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get('token').value) return Astro.redirect('/');
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-all/input.astro
+++ b/test/fixtures/return/return-trailing-comma-all/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-all/output.astro
+++ b/test/fixtures/return/return-trailing-comma-all/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-none/input.astro
+++ b/test/fixtures/return/return-trailing-comma-none/input.astro
@@ -20,7 +20,10 @@
 
 // Test 6: we can return multiple things
   return 1, 2 as const
+
+// Test 7: we can return inline
+	if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
   <div>return</div>

--- a/test/fixtures/return/return-trailing-comma-none/output.astro
+++ b/test/fixtures/return/return-trailing-comma-none/output.astro
@@ -19,8 +19,11 @@ if (false) {
 return `return`;
 
 // Test 6: we can return multiple things
-return (1, 2 as const);
+return 1, 2 as const;
+
+// Test 7: we can return inline
+if (Astro.cookies.get("token").value) return Astro.redirect("/");
 ---
 
-<!-- Test 7: we can use return in HTML -->
+<!-- Test 8: we can use return in HTML -->
 <div>return</div>

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -12,7 +12,7 @@ function getFile(allFiles: any, path: string): string {
 
 it('Correctly errors when parsing faulty frontmatter', async () => {
 	const content = getFile(files, '/test/fixtures/errors/frontmatter.astro');
-	expect(() => format(content, {})).toThrowError('Expression expected');
+	expect(() => format(content, {})).toThrowError('Unexpected token (3:1)');
 });
 
 it('Correctly errors when parsing faulty expressions', async () => {


### PR DESCRIPTION
## Changes

This PR makes it so we use the `babel-ts` parser for the frontmatter, much like we already did for expressions. The differences between the two parsers are not *that* big (case in point: all of our tests passed without changes), but some things can be slightly different at times. Still, since we use that parser already in other places, I figure that now the experience will be more consistant at least

Fix https://github.com/withastro/prettier-plugin-astro/issues/340

## Testing

Tests still pass + updated tests with formatting changes.

## Docs

N/A
