### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Prettier](https://prettier.io/) Plugin for [Astro](https://astro.build/)
 
-Official Prettier plugin adding support for formatting `.astro` files
+Official Prettier plugin adding support for formatting `.astro` files.
 
 ## Installation
 
@@ -8,51 +8,9 @@ Official Prettier plugin adding support for formatting `.astro` files
 npm i --save-dev prettier-plugin-astro prettier
 ```
 
-To customize formatting behavior, see the [Configuration](#configuration) section below
+### Recommended configuration
 
-## Using with the Prettier CLI
-
-When using the CLI, Prettier will automatically pick up the plugin
-
-```shell
-prettier -w .
-```
-
-### pnpm support
-
-Due to [an upstream issue in Prettier](https://github.com/prettier/prettier/issues/8056), the `plugin-search-dir` parameter should be set to the current directory when using pnpm or Prettier won't be able to find the plugin automatically
-
-```shell
-prettier -w --plugin-search-dir=. .
-```
-
-## Using in VS Code
-
-First install the [VS Code Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and add the following settings to your VS Code configuration so VS Code is aware that Prettier can be used for Astro files:
-
-```json
-{
-  "prettier.documentSelectors": ["**/*.astro"]
-}
-```
-
-Additionally, you should set Prettier as the default formatter for Astro files or VS Code will ask you to choose a formatter everytime you format since the Astro VS Code extension also includes a formatter for Astro files:
-
-```json
-{
-  "[astro]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
-}
-```
-
-When submitting issues about formatting in VS Code, first make sure you're actually using Prettier to format your files and not the Astro VS Code extension included formatter
-
-### pnpm support
-
-Due to an upstream issue, Prettier inside VS Code isn't able to automatically infer the right parser to use for Astro files when using pnpm
-
-As such, add the following settings to your `.prettierrc.cjs` config file:
+For optimal compatibility with the different package managers and Prettier plugins, we recommend manually specifying your plugins and the parser to use for Astro files in your Prettier config, like such:
 
 ```js
 module.exports = {
@@ -68,7 +26,27 @@ module.exports = {
 };
 ```
 
-The `require.resolve` call can alternatively be changed to a direct path, like such: `plugins: ["./node_modules/prettier-plugin-astro"]` for usage inside a non-JS config file
+The `require.resolve` call can alternatively be changed to a direct path, like such: `plugins: ["./node_modules/prettier-plugin-astro"]` for usage inside a non-JS config file.
+
+To customize formatting behavior, see the [Configuration](#configuration) section below.
+
+## Using in VS Code
+
+> **Note**
+> If you're using [Astro's VS Code extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode), Prettier and this plugin are already included. Only follow the guide below to format using Prettier's official extension.
+
+First install the [VS Code Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and add the following settings to your VS Code configuration so VS Code is aware that Prettier can be used for Astro files and set it as the default formatter for Astro files:
+
+```json
+{
+  "prettier.documentSelectors": ["**/*.astro"],
+  "[astro]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}
+```
+
+When submitting issues about formatting in VS Code, please specify if you're using the Astro extension or the Prettier extension to format your files.
 
 ## Configuration
 
@@ -77,8 +55,6 @@ Most [options from Prettier](https://prettier.io/docs/en/options.html) will work
 ### Astro Allow Shorthand
 
 Set if attributes with the same name as their expression should be formatted to the short form automatically (for example, if enabled `<element name={name} />` will become simply `<element {name} />`)
-
-> Please note that at the time of writing, [the shorthand form is not currently supported inside the Astro VS Code extension](https://github.com/withastro/language-tools/issues/225)
 
 | Default | CLI Override                     | API Override                  |
 | ------- | -------------------------------- | ----------------------------- |
@@ -94,7 +70,7 @@ Set if attributes with the same name as their expression should be formatted to 
 
 ## Contributing
 
-Pull requests of any size and any skill level are welcome, no contribution is too small. Changes to the Astro Prettier Plugin are subject to [Astro Governance](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) and should adhere to the [Astro Style Guide](https://github.com/withastro/astro/blob/main/STYLE_GUIDE.md)
+Pull requests of any size and any skill level are welcome, no contribution is too small. Changes to the Astro Prettier Plugin are subject to [Astro Governance](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) and should adhere to the [Astro Style Guide](https://github.com/withastro/astro/blob/main/STYLE_GUIDE.md).
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to set up your development environment.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm i --save-dev prettier-plugin-astro prettier
 
 ### Recommended configuration
 
-For optimal compatibility with the different package managers and Prettier plugins, we recommend manually specifying your plugins and the parser to use for Astro files in your Prettier config, like such:
+For optimal compatibility with the different package managers and Prettier plugins, we recommend manually specifying your plugins and the parser to use for Astro files in your Prettier config as shown in the example below:
 
 ```js
 module.exports = {
@@ -26,7 +26,7 @@ module.exports = {
 };
 ```
 
-The `require.resolve` call can alternatively be changed to a direct path, like such: `plugins: ["./node_modules/prettier-plugin-astro"]` for usage inside a non-JS config file.
+Alternatively, for use inside a non-JS config file, the `require.resolve` call can be changed to a direct path, such as `plugins: ["./node_modules/prettier-plugin-astro"]`.
 
 To customize formatting behavior, see the [Configuration](#configuration) section below.
 
@@ -35,7 +35,7 @@ To customize formatting behavior, see the [Configuration](#configuration) sectio
 > **Note**
 > If you're using [Astro's VS Code extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode), Prettier and this plugin are already included. Only follow the guide below to format using Prettier's official extension.
 
-First install the [VS Code Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and add the following settings to your VS Code configuration so VS Code is aware that Prettier can be used for Astro files and set it as the default formatter for Astro files:
+First install the [VS Code Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and add the following settings to your VS Code configuration:
 
 ```json
 {
@@ -46,7 +46,11 @@ First install the [VS Code Prettier extension](https://marketplace.visualstudio.
 }
 ```
 
-When submitting issues about formatting in VS Code, please specify if you're using the Astro extension or the Prettier extension to format your files.
+ The settings above ensure that VS Code is aware that Prettier can be used for Astro files, and sets Prettier as the default formatter for Astro files.
+
+### Reporting issues
+
+When submitting issues about formatting your `.astro` files in VS Code, please specify which extension you are using to format your files: Astro's own extension or the Prettier extension.
 
 ## Configuration
 


### PR DESCRIPTION
## Changes

The README was slightly outdated, so this PR updates the part that are now wrong. Additionally, users are often confused about Prettier's auto-loading for plugins, and since numerous tools and other plugins are incompatible with it, we'll now just tell users to set things manually.

Fix https://github.com/withastro/prettier-plugin-astro/issues/334

## Testing

N/A

## Docs

It's all docs!
