### PR TITLE
fix: prevent parsing empty script tags

### DIFF
--- a/.changeset/healthy-lemons-marry.md
+++ b/.changeset/healthy-lemons-marry.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+fix: prevent parsing empty script tags

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -115,7 +115,7 @@ export function embed(
 	}
 
 	// Script tags
-	if (node.type === 'element' && node.name === 'script') {
+	if (node.type === 'element' && node.name === 'script' && node.children.length) {
 		const typeAttribute = node.attributes.find((attr) => attr.name === 'type')?.value;
 
 		let parser: BuiltInParserName = 'babel-ts';

--- a/test/fixtures/other/script-types/input.astro
+++ b/test/fixtures/other/script-types/input.astro
@@ -6,3 +6,5 @@
 			 }
 	 }
 </script>
+
+<script type="application/ld+json"></script>

--- a/test/fixtures/other/script-types/output.astro
+++ b/test/fixtures/other/script-types/output.astro
@@ -6,3 +6,5 @@
     }
   }
 </script>
+
+<script type="application/ld+json"></script>


### PR DESCRIPTION
## Changes

Prevents trying to parse and format empty script tags

## Testing

Adds an empty json typed script tag to the other-scripts test suite

## Docs

bug fix only

resolves: #346 