### PR TITLE
Add congrats bot

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -1,0 +1,14 @@
+name: Congratsbot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  congrats:
+    if: ${{ github.repository_owner == 'withastro' && github.event.head_commit.message != '[ci] format' }}
+    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    with:
+      EMOJIS: '💐,🌼,🌻,🌹,🌺,🪷,🌷,🏵️'
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}


### PR DESCRIPTION
## Changes
- Adds our Discord congrats bot to this merges in this repo.
- Posts in `#dev-tooling` on Discord (I was able to add the secret to this repo myself).
- Uses a set of flower emoji to distinguish messages from language-tools messages in that channel:
   <img width="212" alt="image" src="https://github.com/withastro/prettier-plugin-astro/assets/357379/54b4d25c-a66f-4e25-9932-6c19091ee18a">
- Will be posted by Prettierston:
   <img width="318" alt="image" src="https://github.com/withastro/prettier-plugin-astro/assets/357379/9fa91367-644d-402c-8415-b12d69267291">


## Testing

Same action we use in other repos

## Docs

N/A