### PR TITLE
chore(package.json): remove pnpm from engines

### DIFF
--- a/.changeset/six-spies-roll.md
+++ b/.changeset/six-spies-roll.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+removes pnpm from engines

--- a/.changeset/six-spies-roll.md
+++ b/.changeset/six-spies-roll.md
@@ -1,5 +1,5 @@
 ---
-'prettier-plugin-astro': minor
+'prettier-plugin-astro': patch
 ---
 
 removes pnpm from engines

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "workers/*"
   ],
   "engines": {
-    "node": "^14.15.0 || >=16.0.0",
-    "pnpm": ">=7.14.0"
+    "node": "^14.15.0 || >=16.0.0"
   },
   "packageManager": "pnpm@8.6.2",
   "homepage": "https://github.com/withastro/prettier-plugin-astro/",


### PR DESCRIPTION
## Changes

removes pnpm from engines, as it is not a javascript engine.

![screenshot: warning from package manager](https://github.com/withastro/prettier-plugin-astro/assets/74759624/6e214e60-2e69-4261-9c58-7560e9595722)

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
