### PR TITLE
docs: update README for Prettier 3 ESM configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,19 @@ Official Prettier plugin adding support for formatting `.astro` files.
 
 ## Installation
 
+First install Prettier and the plugin:
+
 ```shell
-npm i --save-dev prettier-plugin-astro prettier
+npm i --save-dev prettier prettier-plugin-astro
+```
+
+Then add the plugin to your Prettier configuration:
+
+```js
+/** @type {import("prettier").Config} */
+export default {
+  plugins: ['prettier-plugin-astro'],
+};
 ```
 
 ### Recommended configuration
@@ -13,8 +24,9 @@ npm i --save-dev prettier-plugin-astro prettier
 For optimal compatibility with the different package managers and Prettier plugins, we recommend manually specifying the parser to use for Astro files in your Prettier config as shown in the example below:
 
 ```js
-module.exports = {
-  plugins: [require.resolve('prettier-plugin-astro')],
+/** @type {import("prettier").Config} */
+export default {
+  plugins: ['prettier-plugin-astro'],
   overrides: [
     {
       files: '*.astro',
@@ -25,8 +37,6 @@ module.exports = {
   ],
 };
 ```
-
-Alternatively, for use inside a non-JS config file, the `require.resolve` call can be changed to a direct path, such as `plugins: ["./node_modules/prettier-plugin-astro"]`.
 
 To customize formatting behavior, see the [Configuration](#configuration) section below.
 


### PR DESCRIPTION
## Changes

Prettier support ESM configs now and requires plugins to be specified a bit differently

## Testing

N/A

## Docs

It's all docs!
