### PR TITLE
Format doctype as lowercase to match Prettier 3.0

### DIFF
--- a/.changeset/grumpy-ears-chew.md
+++ b/.changeset/grumpy-ears-chew.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+Format doctype as lowercase to match Prettier 3.0

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -319,7 +319,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 
 		case 'doctype': {
 			// https://www.w3.org/wiki/Doctypes_and_markup_styles
-			return ['<!DOCTYPE html>', hardline];
+			return ['<!doctype html>', hardline];
 		}
 
 		case 'comment':

--- a/test/fixtures/basic/basic-html/output.astro
+++ b/test/fixtures/basic/basic-html/output.astro
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/test/fixtures/other/doctype-with-embedded-expr/output.astro
+++ b/test/fixtures/other/doctype-with-embedded-expr/output.astro
@@ -6,7 +6,7 @@ let title = "My Site";
 const colors = ["red", "yellow", "blue"];
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>My site</title>

--- a/test/fixtures/other/doctype-with-extra-attributes/output.astro
+++ b/test/fixtures/other/doctype-with-extra-attributes/output.astro
@@ -6,7 +6,7 @@ let title = "My Site";
 const colors = ["red", "yellow", "blue"];
 ---
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">
   <head>
     <title>My site</title>

--- a/test/fixtures/other/fragment/output.astro
+++ b/test/fixtures/other/fragment/output.astro
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Changes

Prettier 3.0 changed doctype to be lowercase. This PR changes prettier-plugin-astro to also set a lowercase doctype.

https://prettier.io/blog/2023/07/05/3.0.0.html#print-html5-doctype-in-lowercase-7391httpsgithubcomprettierprettierpull7391-by-fiskerhttpsgithubcomfisker

## Testing

<!-- How was this change tested? -->
Test fixtures were updated for the expected output of lowercase doctype. There is one test fixture that was already commented out, but I updated it as well in case it is ever used again.

## Docs

<!-- Was public documentation updated? -->
This is documented in the Prettier docs.