### PR TITLE
Readme: Clarify filename of prettierrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm i --save-dev prettier prettier-plugin-astro
 Then add the plugin to your Prettier configuration:
 
 ```js
+// .prettierrc.mjs
 /** @type {import("prettier").Config} */
 export default {
   plugins: ['prettier-plugin-astro'],
@@ -24,6 +25,7 @@ export default {
 For optimal compatibility with the different package managers and Prettier plugins, we recommend manually specifying the parser to use for Astro files in your Prettier config as shown in the example below:
 
 ```js
+// .prettierrc.mjs
 /** @type {import("prettier").Config} */
 export default {
   plugins: ['prettier-plugin-astro'],


### PR DESCRIPTION
The Readme uses a specific way to specify the prettierrc configs but does not explicitly state which file name is used. 

Prettier supports all kinds of formats (https://prettier.io/docs/en/configuration.html). I had to lookup that this is likely the format referenced here.

By making this more explicit it makes it easier to use the given example.