### PR TITLE
Fix: typo in `CONTRIBUTING.md` and broken links on `elements.ts`

### DIFF
--- a/.changeset/shy-olives-count.md
+++ b/.changeset/shy-olives-count.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Fix typo in CONTRIBUTING.md

--- a/.changeset/shy-olives-count.md
+++ b/.changeset/shy-olives-count.md
@@ -1,5 +1,0 @@
----
-'prettier-plugin-astro': patch
----
-
-Fix typo in `CONTRIBUTING.md` and fix broken links in `elements.ts`

--- a/.changeset/shy-olives-count.md
+++ b/.changeset/shy-olives-count.md
@@ -2,4 +2,4 @@
 'prettier-plugin-astro': patch
 ---
 
-Fix typo in CONTRIBUTING.md
+Fix typo in `CONTRIBUTING.md` and fix broken links in `elements.ts`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 1. `git clone git@github.com:withastro/prettier-plugin-astro.git`
 1. `pnpm install`
 1. `pnpm build`
-1. Run [tests](https://vitest.dev/guide/) with `pnpm test` or `pnpm test:w` for watch mode
+1. Run [tests](https://vitest.dev/guide/) with `pnpm test` or `pnpm test:watch` for watch mode
 1. Lint code with `pnpm lint`
 1. Format code with `pnpm format`
 1. Run `pnpm changeset` to add your changes to the changelog on version bump.

--- a/src/printer/elements.ts
+++ b/src/printer/elements.ts
@@ -1,6 +1,6 @@
 export type TagName = keyof HTMLElementTagNameMap | 'svg';
 
-// https://github.com/prettier/prettier/blob/main/vendors/html-void-elements.json
+// https://github.com/prettier/prettier/blob/b77d912c0c1a5df85e3e9b5b192fc92523e411ee/vendors/html-void-elements.json
 export const selfClosingTags = [
 	'area',
 	'base',
@@ -28,7 +28,7 @@ export const selfClosingTags = [
 	'wbr',
 ];
 
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#Elements
+// https://web.archive.org/web/20230108213516/https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#elements
 export const blockElements: TagName[] = [
 	'address',
 	'article',


### PR DESCRIPTION
Hi, while trying it out I stumbled upon this.
## Changes

1. `CONTRIBUTING.md` `test:w` command renamed to `test:watch` following https://github.com/withastro/prettier-plugin-astro/commit/05f8e2df2ccddf4c488ebb624737eb0818556854#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34

2. Replaced broken links on `elements.ts` with archived version, PRs for reference:
MDN: https://www.github.com/mdn/content/pull/25891/files#diff-27a6658f50aeee036c920e40bcb54176d2c5a1989935299c6d6fa5897dcb799d
Prettier:  https://www.github.com/prettier/prettier/pull/14110/files#diff-1c305ad8dbf49f559152ee113c75972777ebc5ed0d8b0f04e91203d8b2324156

## Testing

No testing is needed

## Docs

No docs update needed