### PR TITLE
fix: hug when needed for components and fragments

### DIFF
--- a/.changeset/khaki-parrots-yawn.md
+++ b/.changeset/khaki-parrots-yawn.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': minor
+---
+
+Fix plugin sometimes including significant whitespace inside components, fragments and custom elements

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -239,7 +239,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 					}
 					if (!hugEnd && lastChild && isTextNode(lastChild)) {
 						if (isInlineElement(path, opts, node) && !didSetEndSeparator) {
-							noHugSeparatorEnd = softline;
+							noHugSeparatorEnd = line;
 						}
 						trimTextNodeRight(lastChild);
 					}

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -27,7 +27,7 @@ export const dotReplace = 'ωP_';
 export const interrogationReplace = 'ΔP_';
 
 export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNode): boolean {
-	return node && node.type === 'element' && !isBlockElement(node, opts) && !isPreTagContent(path);
+	return node && isTagLikeNode(node) && !isBlockElement(node, opts) && !isPreTagContent(path);
 }
 
 export function isBlockElement(node: anyNode, opts: ParserOptions): boolean {

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -32,13 +32,10 @@ export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNod
 
 export function isBlockElement(node: anyNode, opts: ParserOptions): boolean {
 	return (
-		(node &&
-			node.type === 'element' &&
-			opts.htmlWhitespaceSensitivity !== 'strict' &&
-			(opts.htmlWhitespaceSensitivity === 'ignore' ||
-				blockElements.includes(node.name as TagName))) ||
-		node.type === 'component' ||
-		node.type === 'fragment'
+		node &&
+		node.type === 'element' &&
+		opts.htmlWhitespaceSensitivity !== 'strict' &&
+		(opts.htmlWhitespaceSensitivity === 'ignore' || blockElements.includes(node.name as TagName))
 	);
 }
 
@@ -124,10 +121,6 @@ export function hasSetDirectives(node: TagLikeNode) {
  */
 export function shouldHugStart(node: anyNode, opts: ParserOptions): boolean {
 	if (isBlockElement(node, opts)) {
-		return false;
-	}
-
-	if (node.type === 'fragment') {
 		return false;
 	}
 

--- a/test/fixtures/basic/html-custom-elements/output.astro
+++ b/test/fixtures/basic/html-custom-elements/output.astro
@@ -1,1 +1,1 @@
-<custom-element></custom-element>
+<custom-element> </custom-element>

--- a/test/fixtures/markdown/embedded-in-markdown/input.md
+++ b/test/fixtures/markdown/embedded-in-markdown/input.md
@@ -59,9 +59,7 @@ For best results, you should only have one `<style>` tag per-Astro component. Th
       }
     </style>
   </head>
-  <body>
-    ...
-  </body>
+  <body> ...</body>
 </html>
 ```
 

--- a/test/fixtures/other/fragment/input.astro
+++ b/test/fixtures/other/fragment/input.astro
@@ -11,5 +11,9 @@
             Hello world!</>
           <Fragment>
             <span>lorem</span></Fragment>
+						<>Hello world!
+						</>
+          <Fragment><span>lorem</span>
+					</Fragment>
         </body>
 </html>

--- a/test/fixtures/other/fragment/output.astro
+++ b/test/fixtures/other/fragment/output.astro
@@ -7,9 +7,9 @@
     <title>Document</title>
   </head>
   <body>
-    <>Hello world!</>
-    <Fragment>
-      <span>lorem</span>
-    </Fragment>
+    <> Hello world!</>
+    <Fragment> <span>lorem</span></Fragment>
+    <>Hello world! </>
+    <Fragment><span>lorem</span> </Fragment>
   </body>
 </html>


### PR DESCRIPTION
## Changes

Previously, components, fragments and custom elements were considered to be block elements, this is kinda incorrect as they're all whitespace sensitive by default.

In the future, a better way would be to be CSS-based, like Prettier itself is. But that's a much larger refactor.

Fix https://github.com/withastro/prettier-plugin-astro/issues/352

## Testing

Updated tests for this

## Docs

N/A