### PR TITLE
[FEAT] Add option to skip formatting the Frontmatter

### DIFF
--- a/.changeset/thirty-rockets-confess.md
+++ b/.changeset/thirty-rockets-confess.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": minor
+---
+
+Adds a new option called `astroSkipFrontmatter` to disable formatting the frontmatter. This can be useful when using other tools to format the frontmatter, such as Biome or dprint.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,20 @@ Set if attributes with the same name as their expression should be formatted to 
 | ------- | -------------------------------- | ----------------------------- |
 | `false` | `--astro-allow-shorthand <bool>` | `astroAllowShorthand: <bool>` |
 
+### Astro Skip Frontmatter
+
+If you are using another tool to format your JavaScript code, like Biome for example, it is possible to skip formatting the frontmatter.
+
+| Default | CLI Override                     | API Override                  |
+| ------- | -------------------------------- | ----------------------------- |
+| `false` | `--astro-skip-frontmatter <bool>` | `astroSkipFrontmatter: <bool>` |
+
 ### Example `.prettierrc.cjs`
 
 ```js
 {
   astroAllowShorthand: false;
+  astroSkipFrontmatter: false;
 }
 ```
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,6 +22,6 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
 		category: 'Astro',
 		type: 'boolean',
 		default: false,
-		description: 'Skips the formatting of the frontmatter.'
+		description: 'Skips the formatting of the frontmatter.',
 	},
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ import type { SupportOption } from 'prettier';
 
 interface PluginOptions {
 	astroAllowShorthand: boolean;
+	astroSkipFrontmatter: boolean;
 }
 
 declare module 'prettier' {
@@ -16,5 +17,11 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
 		type: 'boolean',
 		default: false,
 		description: 'Enable/disable attribute shorthand if attribute name and expression are the same',
+	},
+	astroSkipFrontmatter: {
+		category: 'Astro',
+		type: 'boolean',
+		default: false,
+		description: 'Skips the formatting of the frontmatter.'
 	},
 };

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -123,6 +123,10 @@ export const embed = ((path: AstPath, options: Options) => {
 
 		// Frontmatter
 		if (node.type === 'frontmatter') {
+			if (options.astroSkipFrontmatter) {
+				return [group(['---', node.value, '---', hardline]), hardline]
+			}
+
 			const frontmatterContent = await wrapParserTryCatch(textToDoc, node.value, {
 				...options,
 				parser: 'babel-ts',

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -124,7 +124,7 @@ export const embed = ((path: AstPath, options: Options) => {
 		// Frontmatter
 		if (node.type === 'frontmatter') {
 			if (options.astroSkipFrontmatter) {
-				return [group(['---', node.value, '---', hardline]), hardline]
+				return [group(['---', node.value, '---', hardline]), hardline];
 			}
 
 			const frontmatterContent = await wrapParserTryCatch(textToDoc, node.value, {

--- a/test/fixtures/options/option-astro-allow-skip-frontmatter-true/input.astro
+++ b/test/fixtures/options/option-astro-allow-skip-frontmatter-true/input.astro
@@ -1,0 +1,6 @@
+---
+			import Comp from "./comp.astro"
+---
+    <Comp options={options} />
+    <Comp options={  options  } />
+    <Comp options={ options } />

--- a/test/fixtures/options/option-astro-allow-skip-frontmatter-true/options.json
+++ b/test/fixtures/options/option-astro-allow-skip-frontmatter-true/options.json
@@ -1,0 +1,3 @@
+{
+	"astroAllowSkipFrontmatter": true
+}

--- a/test/fixtures/options/option-astro-allow-skip-frontmatter-true/options.json
+++ b/test/fixtures/options/option-astro-allow-skip-frontmatter-true/options.json
@@ -1,3 +1,3 @@
 {
-	"astroAllowSkipFrontmatter": true
+  "astroAllowSkipFrontmatter": true
 }

--- a/test/fixtures/options/option-astro-allow-skip-frontmatter-true/output.astro
+++ b/test/fixtures/options/option-astro-allow-skip-frontmatter-true/output.astro
@@ -1,0 +1,7 @@
+---
+			import Comp from "./comp.astro"
+---
+
+<Comp options={options} />
+<Comp options={options} />
+<Comp options={options} />


### PR DESCRIPTION
## Changes

I know this is a very specific use case, but I thought: Why not? Maybe someone else will find useful.

- Adds a new option called "astroSkipFrontmatter" that preserves the content of the front matter. Useful for when the developer wants to format only the template.
- This is useful for integrating with other tools like Biome (https://biomejs.dev) that can format and lint Astro's frontmatter but not the template/html (yet). 

My use case: I added a new script to my package.json that can format all my astro components without interfering with BIome's onSave lint/format.

## Testing

- Added fixtures for the new option
- Did not add tests for it, since all the other tests for previous options were commented out.

## Docs

- Added new section on README.md describing the option.

Thanks!