### PR TITLE
doc: add `pnpm` installation alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ First install Prettier and the plugin:
 npm i --save-dev prettier prettier-plugin-astro
 ```
 
+<details>
+<summary>Installation with pnpm</summary>
+
+```shell
+pnpm add --save-dev prettier prettier-plugin-astro
+```
+</details>
+
 Then add the plugin to your Prettier configuration:
 
 ```js


### PR DESCRIPTION
## Changes

This PR add the `pnpm` installation alternative to the documentation (`README.md`).

## Testing

N/A

## Docs

- `pnpm` installation alternative added.
