### PR TITLE
Bug fix: formatting loop when using bracketSameLine: true and htmlWhitespaceSensitivity: ignore

### DIFF
--- a/.changeset/brown-oranges-tan.md
+++ b/.changeset/brown-oranges-tan.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+Fixes a bug with formatting empty elements with bracketSameLine: true and htmlWhitespaceSensitivity: ignore

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -155,7 +155,12 @@ export const embed = ((path: AstPath, options: Options) => {
 
 			// print
 			const attributes = path.map(print, 'attributes');
-			const openingTag = group(['<script', indent(group(attributes)), softline, '>']);
+			const openingTag = group([
+				'<script', 
+				indent(group(attributes)), 
+				options.bracketSameLine ? '' : softline,
+				'>'
+			]);
 			return [
 				openingTag,
 				indent([isEmpty ? '' : hardline, formattedScript]),

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -156,10 +156,10 @@ export const embed = ((path: AstPath, options: Options) => {
 			// print
 			const attributes = path.map(print, 'attributes');
 			const openingTag = group([
-				'<script', 
-				indent(group(attributes)), 
+				'<script',
+				indent(group(attributes)),
 				options.bracketSameLine ? '' : softline,
-				'>'
+				'>',
 			]);
 			return [
 				openingTag,

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -177,7 +177,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						isTextNodeStartingWithWhitespace(node.children[0]) &&
 						!isPreTagContent(path)
 							? () => line
-							: () => node.children.length > 0 ? softline : '';
+							: () => (node.children.length > 0 ? softline : '');
 				} else if (isPreTagContent(path)) {
 					body = () => printRaw(node);
 				} else if (isInlineElement(path, opts, node) && !isPreTagContent(path)) {

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -177,7 +177,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						isTextNodeStartingWithWhitespace(node.children[0]) &&
 						!isPreTagContent(path)
 							? () => line
-							: () => softline;
+							: () => node.children.length > 0 ? softline : '';
 				} else if (isPreTagContent(path)) {
 					body = () => printRaw(node);
 				} else if (isInlineElement(path, opts, node) && !isPreTagContent(path)) {

--- a/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/input.astro
+++ b/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/input.astro
@@ -1,0 +1,5 @@
+<script
+  is:inline
+  src="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+  crossorigin="anonymous">
+</script>

--- a/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/options.json
+++ b/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/options.json
@@ -1,0 +1,4 @@
+{
+  "bracketSameLine": true,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/output.astro
+++ b/test/fixtures/options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore/output.astro
@@ -1,0 +1,4 @@
+<script
+  is:inline
+  src="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+  crossorigin="anonymous"></script>

--- a/test/tests/options.test.ts
+++ b/test/tests/options.test.ts
@@ -200,6 +200,14 @@ test(
 	'options/single-attribute-per-line-false',
 );
 
+// https://prettier.io/docs/options.html#bracket-line
+// https://prettier.io/docs/en/options.html#html-whitespace-sensitivity
+test(
+	'Can format an Astro file with prettier "bracketSameLine: true, htmlWhitespaceSensitivity: ignore" options',
+	files,
+	'options/option-bracket-same-line-html-true-whitespace-sensitivity-ignore',
+);
+
 // // astro option: astroSortOrder
 // test('Can format an Astro file with prettier "astroSortOrder: markup | styles" option',  'option-astro-sort-order-markup-styles');
 


### PR DESCRIPTION
## Changes

This PR fixes a formatting loop when using the following prettier options to format a multiline empty element
```
{
  "bracketSameLine": true,
  "htmlWhitespaceSensitivity": "ignore
}
```

The loop goes like this:
```
➜ cat test.astro
<script is:inline src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-123456" crossorigin="anonymous"></script>

➜ pnpm exec prettier test.astro --write
test.astro 236ms

➜ cat test.astro
<script
  is:inline
  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-123456"
  crossorigin="anonymous">
</script>

➜ pnpm exec prettier test.astro --check
Checking formatting...
[warn] test.astro
[warn] Code style issues found in the above file. Run Prettier with --write to fix.

➜ pnpm exec prettier test.astro --write
test.astro 106ms

➜ cat test.astro
<script
  is:inline
  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-123456"
  crossorigin="anonymous"
></script>

➜ pnpm exec prettier test.astro --check
Checking formatting...
[warn] test.astro
[warn] Code style issues found in the above file. Run Prettier with --write to fix.

➜ pnpm exec prettier test.astro --write
test.astro 104ms

➜ cat test.astro
<script
  is:inline
  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-123456"
  crossorigin="anonymous">
</script>
```

## Testing
Automated tests added

## Docs
Bug fix. No docs.