### PR TITLE
Format custom elements & components as block elements with htmlWhitespaceSensitivity: ignore

### DIFF
--- a/.changeset/slimy-plums-learn.md
+++ b/.changeset/slimy-plums-learn.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+Format custom elements & components as block elements with htmlWhitespaceSensitivity: ignore

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -31,11 +31,20 @@ export function isInlineElement(path: AstPath, opts: ParserOptions, node: anyNod
 }
 
 export function isBlockElement(node: anyNode, opts: ParserOptions): boolean {
+	if (!node) {
+		return false;
+	}
+
+	// All tags (element, custom-element, component, fragment) are considered
+	// block elements when htmlWhitespaceSensitivity is set to "ignore".
+	if (opts.htmlWhitespaceSensitivity === 'ignore') {
+		return true;
+	}
+
 	return (
-		node &&
 		node.type === 'element' &&
 		opts.htmlWhitespaceSensitivity !== 'strict' &&
-		(opts.htmlWhitespaceSensitivity === 'ignore' || blockElements.includes(node.name as TagName))
+		blockElements.includes(node.name as TagName)
 	);
 }
 

--- a/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/input.astro
+++ b/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/input.astro
@@ -1,0 +1,8 @@
+---
+import Link from "@/components/link.astro";
+---
+
+<ul>
+    <li><a href="https://github.com/withastro/prettier-plugin-astro">Prettier Plugin for Astro (using HTML element)</a></li>
+    <li><Link href="https://github.com/withastro/prettier-plugin-astro">Prettier Plugin for Astro (using component)</Link></li>
+</ul>

--- a/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/options.json
+++ b/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/options.json
@@ -1,0 +1,4 @@
+{
+  "bracketSameLine": true,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/output.astro
+++ b/test/fixtures/options/option-html-whitespace-sensitivity-ignore-component/output.astro
@@ -1,0 +1,16 @@
+---
+import Link from "@/components/link.astro";
+---
+
+<ul>
+  <li>
+    <a href="https://github.com/withastro/prettier-plugin-astro">
+      Prettier Plugin for Astro (using HTML element)
+    </a>
+  </li>
+  <li>
+    <Link href="https://github.com/withastro/prettier-plugin-astro">
+      Prettier Plugin for Astro (using component)
+    </Link>
+  </li>
+</ul>

--- a/test/tests/options.test.ts
+++ b/test/tests/options.test.ts
@@ -185,6 +185,11 @@ test(
 	files,
 	'options/option-html-whitespace-sensitivity-ignore',
 );
+test(
+	'Can format components with prettier "htmlWhitespaceSensitivity: ignore" option',
+	files,
+	'options/option-html-whitespace-sensitivity-ignore-component',
+);
 
 // https://prettier.io/docs/en/options.html#single-attribute-per-line
 test(


### PR DESCRIPTION
## Changes

Consistently treat custom element & components the same way as HTML elements when `htmlWhitespaceSensitivity` is set to `ignore`, e.g.

Input:
```
<Link href="https://github.com/withastro/prettier-plugin-astro">Prettier Plugin for Astro (using component)</Link>
```

Before:
```
<Link href="https://github.com/withastro/prettier-plugin-astro"
  >Prettier Plugin for Astro (using component)</Link
>
```

After
```
<Link href="https://github.com/withastro/prettier-plugin-astro">
  Prettier Plugin for Astro (using component)
</Link>
```

## Testing
Test added

## Docs
Not needed
