### PR TITLE
fix: format long last child of block parent idempotently

### DIFF
--- a/.changeset/new-toys-pump.md
+++ b/.changeset/new-toys-pump.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+Fix non-idempontent formatting for a long last child of a block parent

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -2,7 +2,6 @@ import { type Doc } from 'prettier';
 import { selfClosingTags } from './elements';
 import { type TextNode } from './nodes';
 import {
-	canOmitSoftlineBeforeClosingTag,
 	endsWithLinebreak,
 	getNextNode,
 	getPreferredQuote,
@@ -207,12 +206,10 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						group(['>', body(), `</${node.name}`]),
 					];
 
-					const omitSoftlineBeforeClosingTag =
-						isEmpty || canOmitSoftlineBeforeClosingTag(path, opts);
 					return group([
 						...openingTag,
 						isEmpty ? group(huggedContent) : group(indent(huggedContent)),
-						omitSoftlineBeforeClosingTag ? '' : softline,
+						isEmpty ? '' : softline,
 						'>',
 					]);
 				}
@@ -259,7 +256,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 						...openingTag,
 						'>',
 						indent([noHugSeparatorStart, group([body(), `</${node.name}`])]),
-						canOmitSoftlineBeforeClosingTag(path, opts) ? '' : softline,
+						softline,
 						'>',
 					]);
 				}

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -170,26 +170,8 @@ export function shouldHugEnd(node: anyNode, opts: ParserOptions): boolean {
 	return !isTextNodeEndingWithWhitespace(lastChild);
 }
 
-/**
- * Returns true if the softline between `</tagName` and `>` can be omitted.
- */
-export function canOmitSoftlineBeforeClosingTag(path: AstPath, opts: ParserOptions): boolean {
-	return isLastChildWithinParentBlockElement(path, opts);
-}
-
 function getChildren(node: anyNode): Node[] {
 	return isNodeWithChildren(node) ? node.children : [];
-}
-
-function isLastChildWithinParentBlockElement(path: AstPath, opts: ParserOptions): boolean {
-	const parent = path.getParentNode();
-	if (!parent || !isBlockElement(parent, opts)) {
-		return false;
-	}
-
-	const children = getChildren(parent);
-	const lastChild = children[children.length - 1];
-	return lastChild === path.getNode();
 }
 
 export function trimTextNodeLeft(node: TextNode): void {

--- a/test/fixtures/other/long-last-child-of-block-parent/input.astro
+++ b/test/fixtures/other/long-last-child-of-block-parent/input.astro
@@ -1,0 +1,11 @@
+<p><em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em></p>
+
+<p>
+  <em
+    >aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em>
+</p>
+
+<p>
+  <em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em
+  >
+</p>

--- a/test/fixtures/other/long-last-child-of-block-parent/output.astro
+++ b/test/fixtures/other/long-last-child-of-block-parent/output.astro
@@ -1,0 +1,14 @@
+<p>
+  <em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em
+  >
+</p>
+
+<p>
+  <em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em
+  >
+</p>
+
+<p>
+  <em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em
+  >
+</p>

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -136,3 +136,9 @@ test('Can ignore self-closing elements', files, 'other/ignore-self-close');
 test('can format spread attributes', files, 'other/spread-attributes');
 
 test('can format with cursor position', files, 'other/format-with-cursor-position', false, 313);
+
+test(
+	'Formats long last child of block parent idempotently',
+	files,
+	'other/long-last-child-of-block-parent',
+);


### PR DESCRIPTION
## Changes

Previously we’d omit the `softline` before the closing `>` of the last child of a block parent. But if that child doesn’t fit on one line, neither does the parent, so we add a line break before the parent’s closing tag. Then on a second formatting run, that child won’t be the last child anymore, and the second result will be different.

Remove this unnecessary special case so we jump directly to the final result in one step.

- Fixes #457.

```astro
{/* input */}
<p><em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em></p>

{/* formatted once without this fix */}
<p>
  <em
    >aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em>
</p>

{/* formatted with this fix, or twice without this fix */}
<p>
  <em>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</em
  >
</p>
```

## Testing

Added tests from #457. All other tests still pass.

## Docs

This is a bug fix only. Code that was stable under previous formatting will stay unchanged.