### PR TITLE
Fix prettier-ignore truncating self-closing tags and corrupting siblings

### DIFF
--- a/.changeset/lazy-crabs-smile.md
+++ b/.changeset/lazy-crabs-smile.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro": patch
+---
+
+Fixes `<!-- prettier-ignore -->` truncating self-closing tags with attributes and corrupting the output of subsequent siblings

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -4,8 +4,10 @@ import { type TextNode } from './nodes';
 import {
 	canOmitSoftlineBeforeClosingTag,
 	endsWithLinebreak,
+	getEndOffset,
 	getNextNode,
 	getPreferredQuote,
+	getStartOffset,
 	getUnencodedText,
 	hasSetDirectives,
 	isEmptyTextNode,
@@ -62,7 +64,7 @@ export function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
 		ignoreNext = false;
 		return [
 			opts.originalText
-				.slice(opts.locStart(node), opts.locEnd(node))
+				.slice(getStartOffset(node, opts), getEndOffset(path, opts))
 				.split('\n')
 				.map((lineContent, i) => (i == 0 ? [lineContent] : [literalline, lineContent]))
 				.flat(),

--- a/src/printer/utils.ts
+++ b/src/printer/utils.ts
@@ -253,6 +253,72 @@ export function isTextNode(node: anyNode): node is TextNode {
 	return node.type === 'text';
 }
 
+/**
+ * Returns the offset at which the given node starts in the original text.
+ *
+ * The compiler sometimes reports the start of self-closing components after
+ * the leading `<`, so walk back to it when needed.
+ */
+export function getStartOffset(node: anyNode, opts: ParserOptions): number {
+	const start = opts.locStart(node);
+	if (isTagLikeNode(node) && opts.originalText[start] !== '<') {
+		const startOfTag = opts.originalText.lastIndexOf('<', start);
+		if (startOfTag !== -1) return startOfTag;
+	}
+	return start;
+}
+
+/**
+ * Returns the offset at which the given node ends in the original text.
+ *
+ * The compiler can return a missing or incorrect `position.end` for certain
+ * nodes, notably self-closing tags with attributes, so `opts.locEnd(node)`
+ * cannot always be trusted. Since sibling nodes are contiguous in the source
+ * text, the start of the node's next sibling is used as the end of the node
+ * whenever possible. For childless tags without a next sibling, the end of
+ * the tag is found in the original text instead.
+ */
+export function getEndOffset(path: AstPath, opts: ParserOptions): number | undefined {
+	const node = path.getNode();
+	if (!node) return undefined;
+
+	const nextNode = getNextNode(path);
+	if (nextNode) {
+		return opts.locStart(nextNode);
+	}
+
+	if (isTagLikeNode(node) && node.children.length === 0) {
+		const endOfTag = findEndOfTag(opts.originalText, getStartOffset(node, opts));
+		if (endOfTag !== undefined) return endOfTag;
+	}
+
+	return opts.locEnd(node);
+}
+
+/**
+ * Returns the offset right after the `>` closing the tag starting at the given
+ * offset, ignoring any `>` inside quoted attribute values or expressions.
+ */
+function findEndOfTag(text: string, startOffset: number): number | undefined {
+	let quoteChar: string | undefined;
+	let braceDepth = 0;
+	for (let i = startOffset; i < text.length; i++) {
+		const char = text[i];
+		if (quoteChar) {
+			if (char === quoteChar) quoteChar = undefined;
+		} else if (char === '"' || char === "'" || char === '`') {
+			quoteChar = char;
+		} else if (char === '{') {
+			braceDepth++;
+		} else if (char === '}') {
+			braceDepth--;
+		} else if (char === '>' && braceDepth === 0) {
+			return i + 1;
+		}
+	}
+	return undefined;
+}
+
 export function isExpressionNode(node: anyNode): node is ExpressionNode {
 	return node.type === 'expression';
 }

--- a/test/fixtures/other/prettier-ignore-self-closing-component/input.astro
+++ b/test/fixtures/other/prettier-ignore-self-closing-component/input.astro
@@ -1,0 +1,3 @@
+<!-- prettier-ignore -->
+<Image src="/foo.png"    alt="a > b" />
+<p>hello</p>

--- a/test/fixtures/other/prettier-ignore-self-closing-component/output.astro
+++ b/test/fixtures/other/prettier-ignore-self-closing-component/output.astro
@@ -1,0 +1,3 @@
+<!-- prettier-ignore -->
+<Image src="/foo.png"    alt="a > b" />
+<p>hello</p>

--- a/test/fixtures/other/prettier-ignore-self-closing/input.astro
+++ b/test/fixtures/other/prettier-ignore-self-closing/input.astro
@@ -1,0 +1,15 @@
+---
+---
+<html>
+  <head>
+    <Fragment>
+      <!-- prettier-ignore -->
+      <link rel="canonical" href="https://example.com/" />
+      <meta property="og:locale" content="en_US" />
+      <style is:inline>
+        html { font-size: 50px; }
+      </style>
+    </Fragment>
+  </head>
+  <slot />
+</html>

--- a/test/fixtures/other/prettier-ignore-self-closing/output.astro
+++ b/test/fixtures/other/prettier-ignore-self-closing/output.astro
@@ -1,0 +1,19 @@
+---
+
+---
+
+<html>
+  <head>
+    <Fragment>
+      <!-- prettier-ignore -->
+      <link rel="canonical" href="https://example.com/" />
+      <meta property="og:locale" content="en_US" />
+      <style is:inline>
+        html {
+          font-size: 50px;
+        }
+      </style>
+    </Fragment>
+  </head>
+  <slot />
+</html>

--- a/test/tests/other.test.ts
+++ b/test/tests/other.test.ts
@@ -133,6 +133,18 @@ test(
 
 test('Can ignore self-closing elements', files, 'other/ignore-self-close');
 
+test(
+	'Can ignore self-closing tags with attributes without corrupting subsequent siblings',
+	files,
+	'other/prettier-ignore-self-closing',
+);
+
+test(
+	'Can ignore self-closing components with attributes',
+	files,
+	'other/prettier-ignore-self-closing-component',
+);
+
 test('can format spread attributes', files, 'other/spread-attributes');
 
 test('can format with cursor position', files, 'other/format-with-cursor-position', false, 313);


### PR DESCRIPTION
Fixes #462, reported by @jettwayio.

The Astro compiler reports a bogus `position.end` for self-closing tags with attributes (it computes the end as if the tag were just `<name/>`), and omits `position.end` entirely for self-closing components, sometimes also shifting `position.start` past the `<`. The printer's prettier-ignore path sliced `originalText` at those offsets, truncating the ignored tag mid-attribute (`<link r`) and corrupting every following sibling. The existing `ignore-self-close` test passed by coincidence: its `<li/>` fixture has no attributes, the one case where the broken end-offset math is right.

The fix computes the ignored node's true end from the start of its next sibling (siblings are contiguous in source), falling back to a quote/brace-aware scan for the closing `>` on childless tags, and walks the start back to the leading `<` when the compiler misreports it.

Patch changeset included. Two fixture-based regression tests (the issue's repro including the `is:inline` style, and a self-closing component with `>` inside an attribute value) fail without the fix. Full suite: 93 passed, zero new failures; formatting verified idempotent on all fixtures.
